### PR TITLE
fix(evm): utilize eip-712

### DIFF
--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -16,8 +16,8 @@ import {Action} from "contracts/actions/Action.sol";
 import {AllowList} from "contracts/allowlists/AllowList.sol";
 import {Budget} from "contracts/budgets/Budget.sol";
 import {Incentive} from "contracts/incentives/Incentive.sol";
-import {Validator} from "contracts/validators/Validator.sol";
 import {IAuth} from "contracts/auth/IAuth.sol";
+import {AValidator} from "contracts/validators/AValidator.sol";
 
 /// @title Boost Core
 /// @notice The core contract for the Boost protocol
@@ -125,10 +125,10 @@ contract BoostCore is Ownable, ReentrancyGuard {
         boost.action = Action(_makeTarget(type(Action).interfaceId, payload_.action, true));
         boost.allowList = AllowList(_makeTarget(type(AllowList).interfaceId, payload_.allowList, true));
         boost.incentives = _makeIncentives(payload_.incentives, payload_.budget);
-        boost.validator = Validator(
+        boost.validator = AValidator(
             payload_.validator.instance == address(0)
-                ? boost.action.supportsInterface(type(Validator).interfaceId) ? address(boost.action) : address(0)
-                : _makeTarget(type(Validator).interfaceId, payload_.validator, true)
+                ? boost.action.supportsInterface(type(AValidator).interfaceId) ? address(boost.action) : address(0)
+                : _makeTarget(type(AValidator).interfaceId, payload_.validator, true)
         );
         emit BoostCreated(
             _boosts.length - 1,

--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -156,7 +156,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
         _routeClaimFee(boost, referrer_);
 
         // wake-disable-next-line reentrancy (false positive, function is nonReentrant)
-        if (!boost.validator.validate(data_)) revert BoostError.Unauthorized();
+        if (!boost.validator.validate(boostId_, incentiveId_, msg.sender, data_)) revert BoostError.Unauthorized();
         if (
             !boost.incentives[incentiveId_].claim(abi.encode(Incentive.ClaimPayload({target: msg.sender, data: data_})))
         ) revert BoostError.ClaimFailed(msg.sender, data_);

--- a/packages/evm/contracts/actions/AERC721MintAction.sol
+++ b/packages/evm/contracts/actions/AERC721MintAction.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.24;
 
+import {Ownable as AOwnable} from "@solady/auth/Ownable.sol";
 import {ERC721} from "@solady/tokens/ERC721.sol";
 
 import {BoostError} from "contracts/shared/BoostError.sol";
@@ -16,7 +17,7 @@ import {AValidator} from "contracts/validators/AValidator.sol";
 /// @dev The action is expected to be prepared with the data payload for the minting of the token
 /// @dev This a minimal generic implementation that should be extended if additional functionality or customizations are required
 /// @dev It is expected that the target contract has an externally accessible mint function whose selector
-abstract contract AERC721MintAction is ContractAction, AValidator {
+abstract contract AERC721MintAction is ContractAction, AValidator, AOwnable {
     /// @notice The set of validated tokens
     /// @dev This is intended to prevent multiple validations against the same token ID
     mapping(uint256 => bool) public validated;
@@ -49,7 +50,12 @@ abstract contract AERC721MintAction is ContractAction, AValidator {
     /// @return success True if the action has been validated for the user
     /// @dev The first 20 bytes of the payload must be the holder address and the remaining bytes must be an encoded token ID (uint256)
     /// @dev Example: `abi.encode(address(holder), abi.encode(uint256(tokenId)))`
-    function validate(bytes calldata data_, uint256 /* unused */) external virtual override returns (bool success) {
+    function validate(uint256, /*unused*/ uint256, /* unused */ address, /*unused*/ bytes calldata data_)
+        external
+        virtual
+        override
+        returns (bool success)
+    {
         (address holder, bytes memory payload) = abi.decode(data_, (address, bytes));
         uint256 tokenId = uint256(bytes32(payload));
 

--- a/packages/evm/contracts/actions/AERC721MintAction.sol
+++ b/packages/evm/contracts/actions/AERC721MintAction.sol
@@ -9,14 +9,14 @@ import {Cloneable} from "contracts/shared/Cloneable.sol";
 import {Action} from "contracts/actions/Action.sol";
 import {ContractAction} from "contracts/actions/ContractAction.sol";
 import {AContractAction} from "contracts/actions/AContractAction.sol";
-import {Validator} from "contracts/validators/Validator.sol";
+import {AValidator} from "contracts/validators/AValidator.sol";
 
 /// @title ERC721 Mint Action
 /// @notice A primitive action to mint and/or validate that an ERC721 token has been minted
 /// @dev The action is expected to be prepared with the data payload for the minting of the token
 /// @dev This a minimal generic implementation that should be extended if additional functionality or customizations are required
 /// @dev It is expected that the target contract has an externally accessible mint function whose selector
-abstract contract AERC721MintAction is ContractAction, Validator {
+abstract contract AERC721MintAction is ContractAction, AValidator {
     /// @notice The set of validated tokens
     /// @dev This is intended to prevent multiple validations against the same token ID
     mapping(uint256 => bool) public validated;
@@ -43,13 +43,13 @@ abstract contract AERC721MintAction is ContractAction, Validator {
         return super.prepare(data_);
     }
 
-    /// @inheritdoc Validator
+    /// @inheritdoc AValidator
     /// @notice Validate that the action has been completed successfully
     /// @param data_ The data payload for the action `(address holder, (uint256 tokenId))`
     /// @return success True if the action has been validated for the user
     /// @dev The first 20 bytes of the payload must be the holder address and the remaining bytes must be an encoded token ID (uint256)
     /// @dev Example: `abi.encode(address(holder), abi.encode(uint256(tokenId)))`
-    function validate(bytes calldata data_) external virtual override(Validator) returns (bool success) {
+    function validate(bytes calldata data_, uint256 /* unused */) external virtual override returns (bool success) {
         (address holder, bytes memory payload) = abi.decode(data_, (address, bytes));
         uint256 tokenId = uint256(bytes32(payload));
 
@@ -62,7 +62,7 @@ abstract contract AERC721MintAction is ContractAction, Validator {
     }
 
     /// @inheritdoc AContractAction
-    function getComponentInterface() public pure virtual override(AContractAction, Validator) returns (bytes4) {
+    function getComponentInterface() public pure virtual override(AContractAction, AValidator) returns (bytes4) {
         return type(AERC721MintAction).interfaceId;
     }
 
@@ -71,7 +71,7 @@ abstract contract AERC721MintAction is ContractAction, Validator {
         public
         view
         virtual
-        override(AContractAction, Validator)
+        override(AContractAction, AValidator)
         returns (bool)
     {
         return interfaceId == type(AERC721MintAction).interfaceId || super.supportsInterface(interfaceId);

--- a/packages/evm/contracts/actions/Action.sol
+++ b/packages/evm/contracts/actions/Action.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Cloneable} from "contracts/shared/Cloneable.sol";
-import {Validator} from "contracts/validators/Validator.sol";
+import {AValidator} from "contracts/validators/AValidator.sol";
 
 /// @title Boost Action
 /// @notice Abstract contract for a generic Action within the Boost protocol
@@ -17,7 +17,7 @@ abstract contract Action is Cloneable {
     event ActionValidated(address indexed user, bool isValidated, bytes data);
 
     /// @notice The validator for the action (which may be the action itself where appropriate)
-    Validator public immutable VALIDATOR;
+    AValidator public immutable VALIDATOR;
 
     /// @notice Execute the action
     /// @param data_ The data payload for the action

--- a/packages/evm/contracts/shared/BoostLib.sol
+++ b/packages/evm/contracts/shared/BoostLib.sol
@@ -9,7 +9,7 @@ import {AllowList} from "contracts/allowlists/AllowList.sol";
 import {Budget} from "contracts/budgets/Budget.sol";
 import {Cloneable} from "contracts/shared/Cloneable.sol";
 import {Incentive} from "contracts/incentives/Incentive.sol";
-import {Validator} from "contracts/validators/Validator.sol";
+import {AValidator} from "contracts/validators/AValidator.sol";
 
 library BoostLib {
     using LibClone for address;
@@ -18,7 +18,7 @@ library BoostLib {
     /// @notice A struct representing a single Boost
     struct Boost {
         Action action;
-        Validator validator;
+        AValidator validator;
         AllowList allowList;
         Budget budget;
         Incentive[] incentives;

--- a/packages/evm/contracts/shared/IBoostClaim.sol
+++ b/packages/evm/contracts/shared/IBoostClaim.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+interface IBoostClaim {
+    /// @notice A higher order struct for encoding and decoding arbitrary claims
+    struct BoostClaimData {
+        bytes validatorData;
+        bytes incentiveData;
+    }
+}

--- a/packages/evm/contracts/validators/ASignerValidator.sol
+++ b/packages/evm/contracts/validators/ASignerValidator.sol
@@ -3,50 +3,37 @@ pragma solidity ^0.8.24;
 
 import {SignatureCheckerLib} from "@solady/utils/SignatureCheckerLib.sol";
 
-import {Cloneable} from "contracts/shared/Cloneable.sol";
 import {BoostError} from "contracts/shared/BoostError.sol";
+import {Cloneable} from "contracts/shared/Cloneable.sol";
+import {IBoostClaim} from "contracts/shared/IBoostClaim.sol";
 
 import {AValidator} from "contracts/validators/AValidator.sol";
 
 /// @title Signer Validator
 /// @notice A simple implementation of a Validator that verifies a given signature and checks the recovered address against a set of authorized signers
-abstract contract ASignerValidator is AValidator {
+abstract contract ASignerValidator is IBoostClaim, AValidator {
     using SignatureCheckerLib for address;
+
+    struct SignerValidatorInputParams {
+        address signer;
+        bytes signature;
+        uint8 incentiveQuantity;
+    }
+
+    struct SignerValidatorData {
+        uint8 incentiveQuantity;
+        address claimant;
+        uint256 boostId;
+        bytes incentiveData;
+    }
 
     /// @dev The set of authorized signers
     mapping(address => bool) public signers;
 
-    /// @dev The set of used hashes (for replay protection)
-    mapping(bytes32 => bool) internal _used;
-
-    /// @notice Validate that the action has been completed successfully
-    /// @param data_ The data payload for the validation check
-    /// @return True if the action has been validated based on the data payload
-    /// @dev The data payload is expected to be a tuple of (address signer, bytes32 hash, bytes signature)
-    /// @dev The signature is expected to be a valid ECDSA or EIP-1271 signature of a unique hash by an authorized signer
-    function validate(bytes calldata data_) external override returns (bool) {
-        (address signer_, bytes32 hash_, bytes memory signature_) = abi.decode(data_, (address, bytes32, bytes));
-
-        if (!signers[signer_]) revert BoostError.Unauthorized();
-        if (_used[hash_]) revert BoostError.Replayed(signer_, hash_, signature_);
-
-        // Mark the hash as used to prevent replays
-        _used[hash_] = true;
-
-        // Return the result of the signature check
-        return signer_.isValidSignatureNow(SignatureCheckerLib.toEthSignedMessageHash(hash_), signature_);
-    }
-
     /// @notice Set the authorized status of a signer
     /// @param signers_ The list of signers to update
     /// @param authorized_ The authorized status of each signer
-    function setAuthorized(address[] calldata signers_, bool[] calldata authorized_) external onlyOwner {
-        if (signers_.length != authorized_.length) revert BoostError.LengthMismatch();
-
-        for (uint256 i = 0; i < signers_.length; i++) {
-            signers[signers_[i]] = authorized_[i];
-        }
-    }
+    function setAuthorized(address[] calldata signers_, bool[] calldata authorized_) external virtual;
 
     /// @inheritdoc Cloneable
     function getComponentInterface() public pure virtual override(AValidator) returns (bytes4) {

--- a/packages/evm/contracts/validators/ASignerValidator.sol
+++ b/packages/evm/contracts/validators/ASignerValidator.sol
@@ -6,11 +6,11 @@ import {SignatureCheckerLib} from "@solady/utils/SignatureCheckerLib.sol";
 import {Cloneable} from "contracts/shared/Cloneable.sol";
 import {BoostError} from "contracts/shared/BoostError.sol";
 
-import {Validator} from "contracts/validators/Validator.sol";
+import {AValidator} from "contracts/validators/AValidator.sol";
 
 /// @title Signer Validator
 /// @notice A simple implementation of a Validator that verifies a given signature and checks the recovered address against a set of authorized signers
-abstract contract ASignerValidator is Validator {
+abstract contract ASignerValidator is AValidator {
     using SignatureCheckerLib for address;
 
     /// @dev The set of authorized signers
@@ -49,12 +49,12 @@ abstract contract ASignerValidator is Validator {
     }
 
     /// @inheritdoc Cloneable
-    function getComponentInterface() public pure virtual override(Validator) returns (bytes4) {
+    function getComponentInterface() public pure virtual override(AValidator) returns (bytes4) {
         return type(ASignerValidator).interfaceId;
     }
 
     /// @inheritdoc Cloneable
-    function supportsInterface(bytes4 interfaceId) public view virtual override(Validator) returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view virtual override(AValidator) returns (bool) {
         return interfaceId == type(ASignerValidator).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/packages/evm/contracts/validators/AValidator.sol
+++ b/packages/evm/contracts/validators/AValidator.sol
@@ -1,26 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.24;
 
-import {Ownable} from "@solady/auth/Ownable.sol";
-
 import {Cloneable} from "contracts/shared/Cloneable.sol";
 
 /// @title Boost Validator
 /// @notice Abstract contract for a generic Validator within the Boost protocol
 /// @dev Validator classes are expected to decode the calldata for implementation-specific handling. If no data is required, calldata should be empty.
-abstract contract AValidator is Ownable, Cloneable {
-    struct ValidatePayload {
-        address target;
-        bytes data;
-    }
-
+abstract contract AValidator is Cloneable {
     /// @notice Validate that a given user has completed an acction successfully
-    /// @param data The compressed {ValidatePayload} to be validated
+    /// @param boostId The Id from the available boosts
     /// @param incentiveId The Id from the available boost incentives to be claimed
+    /// @param claimant The address of the user claiming the incentive
+    /// @param data The encoded payload to be validated
     /// @return True if the action has been validated based on the data payload
-    /// @dev The decompressed payload contains the address of the user being validated along with freeform bytes that are entirely implementation-specific
-    /// @dev For example, to validate a tuple of `(bytes32 messageHash, bytes signature)` on behalf of `address holder`, the payload should be `ValidatePayload({target: holder, data: abi.encode(messageHash, signature)})`, ABI-encoded and compressed with {LibZip-cdCompress}
-    function validate(bytes calldata data, uint256 incentiveId) external virtual returns (bool);
+    /// @dev The decompressed payload contains freeform bytes that are entirely implementation-specific
+    function validate(uint256 boostId, uint256 incentiveId, address claimant, bytes calldata data)
+        external
+        virtual
+        returns (bool);
 
     /// @inheritdoc Cloneable
     function supportsInterface(bytes4 interfaceId) public view virtual override(Cloneable) returns (bool) {

--- a/packages/evm/contracts/validators/AValidator.sol
+++ b/packages/evm/contracts/validators/AValidator.sol
@@ -8,32 +8,27 @@ import {Cloneable} from "contracts/shared/Cloneable.sol";
 /// @title Boost Validator
 /// @notice Abstract contract for a generic Validator within the Boost protocol
 /// @dev Validator classes are expected to decode the calldata for implementation-specific handling. If no data is required, calldata should be empty.
-abstract contract Validator is Ownable, Cloneable {
+abstract contract AValidator is Ownable, Cloneable {
     struct ValidatePayload {
         address target;
         bytes data;
     }
 
-    /// @notice Initialize the contract and set the owner
-    /// @dev The owner is set to the contract deployer
-    constructor() {
-        _initializeOwner(msg.sender);
-    }
-
     /// @notice Validate that a given user has completed an acction successfully
-    /// @param data_ The compressed {ValidatePayload} to be validated
+    /// @param data The compressed {ValidatePayload} to be validated
+    /// @param incentiveId The Id from the available boost incentives to be claimed
     /// @return True if the action has been validated based on the data payload
     /// @dev The decompressed payload contains the address of the user being validated along with freeform bytes that are entirely implementation-specific
     /// @dev For example, to validate a tuple of `(bytes32 messageHash, bytes signature)` on behalf of `address holder`, the payload should be `ValidatePayload({target: holder, data: abi.encode(messageHash, signature)})`, ABI-encoded and compressed with {LibZip-cdCompress}
-    function validate(bytes calldata data_) external virtual returns (bool);
+    function validate(bytes calldata data, uint256 incentiveId) external virtual returns (bool);
 
     /// @inheritdoc Cloneable
     function supportsInterface(bytes4 interfaceId) public view virtual override(Cloneable) returns (bool) {
-        return interfaceId == type(Validator).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(AValidator).interfaceId || super.supportsInterface(interfaceId);
     }
 
     /// @inheritdoc Cloneable
     function getComponentInterface() public pure virtual override(Cloneable) returns (bytes4) {
-        return type(Validator).interfaceId;
+        return type(AValidator).interfaceId;
     }
 }

--- a/packages/evm/contracts/validators/SignerValidator.sol
+++ b/packages/evm/contracts/validators/SignerValidator.sol
@@ -1,11 +1,28 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.24;
 
+import {Ownable} from "@solady/auth/Ownable.sol";
+
+import {SignatureCheckerLib} from "@solady/utils/SignatureCheckerLib.sol";
+import {EIP712} from "@solady/utils/EIP712.sol";
+
+import {Cloneable} from "contracts/shared/Cloneable.sol";
+import {BoostError} from "contracts/shared/BoostError.sol";
+
+import {AValidator} from "contracts/validators/AValidator.sol";
 import {ASignerValidator} from "contracts/validators/ASignerValidator.sol";
 
 /// @title Signer Validator
 /// @notice A simple implementation of a Validator that verifies a given signature and checks the recovered address against a set of authorized signers
-contract SignerValidator is ASignerValidator {
+contract SignerValidator is ASignerValidator, Ownable, EIP712 {
+    using SignatureCheckerLib for address;
+
+    /// @dev The set of used hashes (for replay protection)
+    mapping(bytes32 => bool) internal _used;
+
+    bytes32 internal constant _SIGNER_VALIDATOR_TYPEHASH =
+        keccak256("SignerValidatorData(uint8 incentiveQuantity,address claimant,uint256 boostId,bytes incentiveData)");
+
     /// @notice Construct a new SignerValidator
     /// @dev Because this contract is a base implementation, it should not be initialized through the constructor. Instead, it should be cloned and initialized using the {initialize} function.
     constructor() {
@@ -21,5 +38,60 @@ contract SignerValidator is ASignerValidator {
         for (uint256 i = 0; i < signers_.length; i++) {
             signers[signers_[i]] = true;
         }
+    }
+
+    /// Validate that the action has been completed successfully by constructing a payload and checking the signature against it
+    /// @inheritdoc AValidator
+    function validate(uint256 boostId, uint256 incentiveId, address claimant, bytes calldata claimData)
+        external
+        override
+        returns (bool)
+    {
+        (BoostClaimData memory claim) = abi.decode(claimData, (BoostClaimData));
+        (SignerValidatorInputParams memory validatorData) =
+            abi.decode(claim.validatorData, (SignerValidatorInputParams));
+
+        bytes32 hash = hashSignerData(boostId, validatorData.incentiveQuantity, claimant, claim.incentiveData);
+        if (!signers[validatorData.signer]) revert BoostError.Unauthorized();
+        if (_used[hash]) revert BoostError.Replayed(validatorData.signer, hash, validatorData.signature);
+
+        // Mark the hash as used to prevent replays
+        _used[hash] = true;
+
+        // Return the result of the signature check
+        // no need for a sig prefix since it's encoded by the EIP712 lib
+        return validatorData.signer.isValidSignatureNow(hash, validatorData.signature);
+    }
+
+    /// @notice Set the authorized status of a signer
+    /// @param signers_ The list of signers to update
+    /// @param authorized_ The authorized status of each signer
+    function setAuthorized(address[] calldata signers_, bool[] calldata authorized_) external override onlyOwner {
+        if (signers_.length != authorized_.length) revert BoostError.LengthMismatch();
+
+        for (uint256 i = 0; i < signers_.length; i++) {
+            signers[signers_[i]] = authorized_[i];
+        }
+    }
+
+    function hashSignerData(uint256 boostId, uint8 incentiveQuantity, address claimant, bytes memory incentiveData)
+        public
+        view
+        returns (bytes32 hashedSignerData)
+    {
+        return _hashTypedData(
+            keccak256(
+                abi.encode(_SIGNER_VALIDATOR_TYPEHASH, incentiveQuantity, claimant, boostId, keccak256(incentiveData))
+            )
+        );
+    }
+
+    function _domainNameAndVersion() internal pure override returns (string memory name, string memory version) {
+        name = "SignerValidator";
+        version = "1";
+    }
+
+    function _domainNameAndVersionMayChange() internal pure override returns (bool result) {
+        result = true;
     }
 }

--- a/packages/evm/test/BoostCore.t.sol
+++ b/packages/evm/test/BoostCore.t.sol
@@ -26,7 +26,7 @@ import {ERC20Incentive} from "contracts/incentives/ERC20Incentive.sol";
 import {AERC20Incentive} from "contracts/incentives/AERC20Incentive.sol";
 
 // Validators
-import {Validator} from "contracts/validators/Validator.sol";
+import {AValidator} from "contracts/validators/AValidator.sol";
 import {SignerValidator} from "contracts/validators/SignerValidator.sol";
 
 // Core and Shared
@@ -88,11 +88,11 @@ contract BoostCoreTest is Test {
     // BoostCore Initial State //
     /////////////////////////////
 
-    function testInitialOwner() public {
+    function testInitialOwner() public view {
         assertEq(address(this), boostCore.owner());
     }
 
-    function testInitialBoostCount() public {
+    function testInitialBoostCount() public view {
         assertEq(0, boostCore.getBoostCount());
     }
 
@@ -144,7 +144,7 @@ contract BoostCoreTest is Test {
         assertEq(_incentive.claims(), 0);
 
         // Check the Validator (which should be the Action)
-        assertTrue(boost.validator.supportsInterface(type(Validator).interfaceId));
+        assertTrue(boost.validator.supportsInterface(type(AValidator).interfaceId));
         assertEq(address(boost.validator), address(boost.action));
     }
 

--- a/packages/evm/test/actions/ERC721MintAction.t.sol
+++ b/packages/evm/test/actions/ERC721MintAction.t.sol
@@ -112,10 +112,10 @@ contract ERC721MintActionTest is Test {
         assertTrue(mockAsset.ownerOf(1) == address(this));
 
         // Validate the action
-        assertTrue(action.validate(0,0, address(0), abi.encode(address(this), abi.encode(1))));
+        assertTrue(action.validate(0, 0, address(0), abi.encode(address(this), abi.encode(1))));
 
         // Validate the action again => false
-        assertFalse(action.validate(0,0, address(0), abi.encode(address(this), abi.encode(1))));
+        assertFalse(action.validate(0, 0, address(0), abi.encode(address(this), abi.encode(1))));
     }
 
     function testValidate_NonExistentToken() public {
@@ -124,7 +124,7 @@ contract ERC721MintActionTest is Test {
 
         // Validate the action with a non-existent token
         vm.expectRevert(ERC721.TokenDoesNotExist.selector);
-        action.validate(0,0, address(0), abi.encode(address(this), abi.encode(1)));
+        action.validate(0, 0, address(0), abi.encode(address(this), abi.encode(1)));
     }
 
     ////////////////////////////////
@@ -140,7 +140,7 @@ contract ERC721MintActionTest is Test {
         assertTrue(mockAsset.ownerOf(1) == address(this));
 
         // Validate the action
-        assertTrue(action.validate(0,0, address(0), abi.encode(address(this), abi.encode(1))));
+        assertTrue(action.validate(0, 0, address(0), abi.encode(address(this), abi.encode(1))));
 
         // Check the validation status of the token
         assertTrue(action.validated(1));

--- a/packages/evm/test/actions/ERC721MintAction.t.sol
+++ b/packages/evm/test/actions/ERC721MintAction.t.sol
@@ -9,7 +9,7 @@ import {LibClone} from "@solady/utils/LibClone.sol";
 import {Action} from "contracts/actions/Action.sol";
 import {BoostError} from "contracts/shared/BoostError.sol";
 import {ERC721MintAction} from "contracts/actions/ERC721MintAction.sol";
-import {Validator} from "contracts/validators/Validator.sol";
+import {AValidator} from "contracts/validators/AValidator.sol";
 
 import {MockERC721} from "contracts/shared/Mocks.sol";
 
@@ -88,7 +88,7 @@ contract ERC721MintActionTest is Test {
         assertTrue(mockAsset.ownerOf(1) == address(this));
 
         // Validate the action
-        assertTrue(action.validate(abi.encode(address(this), abi.encode(1))));
+        assertTrue(action.validate(0, 0, address(0), abi.encode(address(this), abi.encode(1))));
     }
 
     function testValidate_WrongHolder() public {
@@ -100,7 +100,7 @@ contract ERC721MintActionTest is Test {
         assertTrue(mockAsset.ownerOf(1) == address(this));
 
         // Validate the action with an invalid holder
-        assertFalse(action.validate(abi.encode(address(0xdeadbeef), abi.encode(1))));
+        assertFalse(action.validate(0, 0, address(0), abi.encode(address(0xdeadbeef), abi.encode(1))));
     }
 
     function testValidate_AlreadyValidated() public {
@@ -112,10 +112,10 @@ contract ERC721MintActionTest is Test {
         assertTrue(mockAsset.ownerOf(1) == address(this));
 
         // Validate the action
-        assertTrue(action.validate(abi.encode(address(this), abi.encode(1))));
+        assertTrue(action.validate(0,0, address(0), abi.encode(address(this), abi.encode(1))));
 
         // Validate the action again => false
-        assertFalse(action.validate(abi.encode(address(this), abi.encode(1))));
+        assertFalse(action.validate(0,0, address(0), abi.encode(address(this), abi.encode(1))));
     }
 
     function testValidate_NonExistentToken() public {
@@ -124,7 +124,7 @@ contract ERC721MintActionTest is Test {
 
         // Validate the action with a non-existent token
         vm.expectRevert(ERC721.TokenDoesNotExist.selector);
-        action.validate(abi.encode(address(this), abi.encode(1)));
+        action.validate(0,0, address(0), abi.encode(address(this), abi.encode(1)));
     }
 
     ////////////////////////////////
@@ -140,7 +140,7 @@ contract ERC721MintActionTest is Test {
         assertTrue(mockAsset.ownerOf(1) == address(this));
 
         // Validate the action
-        assertTrue(action.validate(abi.encode(address(this), abi.encode(1))));
+        assertTrue(action.validate(0,0, address(0), abi.encode(address(this), abi.encode(1))));
 
         // Check the validation status of the token
         assertTrue(action.validated(1));
@@ -173,7 +173,7 @@ contract ERC721MintActionTest is Test {
 
         // Check the interface support
         assertTrue(action.supportsInterface(type(Action).interfaceId));
-        assertTrue(action.supportsInterface(type(Validator).interfaceId));
+        assertTrue(action.supportsInterface(type(AValidator).interfaceId));
     }
 
     function testSupportsInterface_NotSupported() public {

--- a/packages/evm/test/e2e/EndToEnd.t.sol
+++ b/packages/evm/test/e2e/EndToEnd.t.sol
@@ -29,7 +29,7 @@ import {Incentive} from "contracts/incentives/Incentive.sol";
 import {ERC20Incentive} from "contracts/incentives/ERC20Incentive.sol";
 import {AERC20Incentive} from "contracts/incentives/AERC20Incentive.sol";
 
-import {Validator} from "contracts/validators/Validator.sol";
+import {AValidator} from "contracts/validators/AValidator.sol";
 
 /**
  * @title EndToEnd
@@ -116,7 +116,7 @@ contract EndToEnd is Test {
 
         // - Action == Validator
         assertEq(boost.action.supportsInterface(type(Action).interfaceId), true);
-        assertEq(boost.action.supportsInterface(type(Validator).interfaceId), true);
+        assertEq(boost.action.supportsInterface(type(AValidator).interfaceId), true);
         assertEq(address(boost.validator), address(boost.action));
 
         // - Action == ERC721MintAction

--- a/packages/evm/test/validators/SignerValidator.t.sol
+++ b/packages/evm/test/validators/SignerValidator.t.sol
@@ -12,7 +12,7 @@ import {MockERC1271Malicious} from "lib/solady/test/utils/mocks/MockERC1271Malic
 
 import {BoostError} from "contracts/shared/BoostError.sol";
 import {Cloneable} from "contracts/shared/Cloneable.sol";
-import {Validator} from "contracts/validators/Validator.sol";
+import {AValidator} from "contracts/validators/AValidator.sol";
 import {SignerValidator} from "contracts/validators/SignerValidator.sol";
 
 contract SignerValidatorTest is Test {
@@ -98,10 +98,10 @@ contract SignerValidatorTest is Test {
     //////////////////////////////
 
     function testValidate() public {
-        assertTrue(validator.validate(PACKED_EOA_SIGNATURE));
+        assertTrue(validator.validate(0,0, address(0),PACKED_EOA_SIGNATURE));
 
         vm.expectRevert(BoostError.Unauthorized.selector);
-        validator.validate(PACKED_UNTRUSTED_SIGNATURE);
+        validator.validate(0,0, address(0),PACKED_UNTRUSTED_SIGNATURE);
     }
 
     function testValidate_UnauthorizedSigner() public {
@@ -109,31 +109,31 @@ contract SignerValidatorTest is Test {
         bytes memory signature = _signHash(hash, fakeSignerKey);
         bytes memory data = abi.encode(fakeSigner, hash, signature);
         vm.expectRevert(BoostError.Unauthorized.selector);
-        validator.validate(data);
+        validator.validate(0,0, address(0),data);
     }
 
     function testValidate_ReplayedSignature() public {
         // First validation should pass
-        assertTrue(validator.validate(PACKED_EOA_SIGNATURE));
+        assertTrue(validator.validate(0,0, address(0),PACKED_EOA_SIGNATURE));
 
         // Second (replayed) validation should revert
         vm.expectRevert(
             abi.encodeWithSelector(BoostError.Replayed.selector, testSigner, MESSAGE_HASH, TRUSTED_EOA_SIGNATURE)
         );
-        validator.validate(PACKED_EOA_SIGNATURE);
+        validator.validate(0,0, address(0),PACKED_EOA_SIGNATURE);
     }
 
     function testValidate_SmartContractSigner() public {
-        assertTrue(validator.validate(PACKED_1271_SIGNATURE));
+        assertTrue(validator.validate(0,0, address(0), PACKED_1271_SIGNATURE));
     }
 
     function testValidate_SmartContractSigner_WrongSigner() public {
-        assertFalse(validator.validate(PACKED_WRONG_SIGNATURE));
+        assertFalse(validator.validate(0,0, address(0),PACKED_WRONG_SIGNATURE));
     }
 
     function testValidate_SmartContractSigner_Malicious() public {
         vm.expectRevert(BoostError.Unauthorized.selector);
-        validator.validate(PACKED_MALICIOUS_SIGNATURE);
+        validator.validate(0,0, address(0),PACKED_MALICIOUS_SIGNATURE);
     }
 
     ///////////////////////////////////
@@ -167,7 +167,7 @@ contract SignerValidatorTest is Test {
 
     function testSupportsInterface() public {
         assertTrue(validator.supportsInterface(type(Cloneable).interfaceId));
-        assertTrue(validator.supportsInterface(type(Validator).interfaceId));
+        assertTrue(validator.supportsInterface(type(AValidator).interfaceId));
     }
 
     function testSupportsInterface_NotSupported() public {

--- a/packages/sdk/src/Validators/Validator.ts
+++ b/packages/sdk/src/Validators/Validator.ts
@@ -1,4 +1,4 @@
-import { validatorAbi } from '@boostxyz/evm';
+import { aValidatorAbi } from '@boostxyz/evm';
 import { readContract } from '@wagmi/core';
 import type { Address, Hex } from 'viem';
 import type { DeployableOptions } from '../Deployable/Deployable';
@@ -39,7 +39,7 @@ export async function validatorFromAddress(
   address: Address,
 ) {
   const interfaceId = (await readContract(options.config, {
-    abi: validatorAbi,
+    abi: aValidatorAbi,
     functionName: 'getComponentInterface',
     address,
   })) as keyof typeof ValidatorByComponentInterface;


### PR DESCRIPTION
This prevents cross-chain replays.

The tests can still be streamlined quite a bit, but I'll do this
after/while I implement multi-claims with a valid signature

fixes https://linear.app/rh-app/issue/BOOST-4575/add-eip-712-functionality-to-signervalidator