### PR TITLE
feat(evm): allow SignerValidator to track up to 8 incentives per Boost

### DIFF
--- a/packages/evm/contracts/shared/BoostError.sol
+++ b/packages/evm/contracts/shared/BoostError.sol
@@ -31,4 +31,13 @@ library BoostError {
 
     /// @notice Thrown when the requested action is unauthorized
     error Unauthorized();
+
+    /// @notice Thrown when an incentive id exceeds the available incentives
+    error InvalidIncentive(uint8 available, uint256 id);
+
+    /// @notice thrown when an incentiveId is larger than 7
+    error IncentiveToBig(uint8 incentiveId);
+
+    /// @notice thrown when an incentiveId is already claimed against
+    error IncentiveClaimed(uint8 incentiveId);
 }

--- a/packages/sdk/src/Incentives/AllowListIncentive.test.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.test.ts
@@ -67,7 +67,7 @@ describe('AllowListIncentive', () => {
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
     console.log(claimant);
 
-    const incentiveQuantity = 0;
+    const incentiveQuantity = 1;
     const claimDataPayload = await prepareSignerValidatorClaimDataPayload({
       signer: trustedSigner,
       incentiveData,
@@ -108,7 +108,7 @@ describe('AllowListIncentive', () => {
       allowListIncentive.assertValidAddress(),
       LIST_MANAGER_ROLE,
     );
-    const incentiveQuantity = 0;
+    const incentiveQuantity = 1;
     const claimant = trustedSigner.account;
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
     console.log(claimant);

--- a/packages/sdk/src/Incentives/CGDAIncentive.test.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.test.ts
@@ -58,7 +58,7 @@ describe('CGDAIncentive', () => {
     const claimant = trustedSigner.account;
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
 
-    const incentiveQuantity = 0;
+    const incentiveQuantity = 1;
     const claimDataPayload = await prepareSignerValidatorClaimDataPayload({
       signer: trustedSigner,
       incentiveData,
@@ -103,7 +103,7 @@ describe('CGDAIncentive', () => {
 
     const claimant = trustedSigner.account;
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
-    const incentiveQuantity = 0;
+    const incentiveQuantity = 1;
     const claimDataPayload = await prepareSignerValidatorClaimDataPayload({
       signer: trustedSigner,
       incentiveData,

--- a/packages/sdk/src/Incentives/ERC1155Incentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC1155Incentive.test.ts
@@ -70,7 +70,7 @@ describe('ERC1155Incentive', () => {
 
     const claimant = trustedSigner.account;
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
-    const incentiveQuantity = 0;
+    const incentiveQuantity = 1;
     const claimDataPayload = await prepareSignerValidatorClaimDataPayload({
       signer: trustedSigner,
       incentiveData,

--- a/packages/sdk/src/Incentives/ERC20Incentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.test.ts
@@ -64,7 +64,7 @@ describe('ERC20Incentive', () => {
 
     const claimant = trustedSigner.account;
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
-    const incentiveQuantity = 0;
+    const incentiveQuantity = 1;
     const claimDataPayload = await prepareSignerValidatorClaimDataPayload({
       signer: trustedSigner,
       incentiveData,
@@ -108,7 +108,7 @@ describe('ERC20Incentive', () => {
 
     const claimant = trustedSigner.account;
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
-    const incentiveQuantity = 0;
+    const incentiveQuantity = 1;
     const claimDataPayload = await prepareSignerValidatorClaimDataPayload({
       signer: trustedSigner,
       incentiveData,

--- a/packages/sdk/src/Incentives/PointsIncentive.test.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.test.ts
@@ -54,7 +54,7 @@ describe.skip('PointsIncentive', () => {
 
     const claimant = trustedSigner.account;
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
-    const incentiveQuantity = 0;
+    const incentiveQuantity = 1;
     const claimDataPayload = await prepareSignerValidatorClaimDataPayload({
       signer: trustedSigner,
       incentiveData,
@@ -104,7 +104,7 @@ describe.skip('PointsIncentive', () => {
 
     const claimant = trustedSigner.account;
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
-    const incentiveQuantity = 0;
+    const incentiveQuantity = 1;
     const claimDataPayload = await prepareSignerValidatorClaimDataPayload({
       signer: trustedSigner,
       incentiveData,

--- a/packages/sdk/src/Validators/SignerValidator.test.ts
+++ b/packages/sdk/src/Validators/SignerValidator.test.ts
@@ -54,7 +54,7 @@ describe('SignerValidator', () => {
     // Define the input data
     const boostId = 5n;
     const incentiveQuantity = 1;
-    const incentiveId = 1n;
+    const incentiveId = 0n;
     const claimant = '0x24582544C98a86eE59687c4D5B55D78f4FffA666';
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
 
@@ -111,7 +111,7 @@ describe('SignerValidator', () => {
     // Define the input data
     const boostId = 5n;
     const incentiveQuantity = 1;
-    const incentiveId = 1n;
+    const incentiveId = 0n;
     const claimant = '0x24582544C98a86eE59687c4D5B55D78f4FffA666';
     const incentiveData = pad('0xdef456232173821931823712381232131391321934');
 


### PR DESCRIPTION
This bitmap allows a single signature to allow the claiming of up to 8
incentives. We can enable more claims, it's just a question of utilizing
more storage in exchange for more possible incentives supported in a
given boost.

# merge plan

merge after #42 
