### PR TITLE
[Boost-4578] Lock down 'validate` SignerValidator access

### DIFF
--- a/packages/evm/contracts/validators/ASignerValidator.sol
+++ b/packages/evm/contracts/validators/ASignerValidator.sol
@@ -35,6 +35,10 @@ abstract contract ASignerValidator is IBoostClaim, AValidator {
     /// @param authorized_ The authorized status of each signer
     function setAuthorized(address[] calldata signers_, bool[] calldata authorized_) external virtual;
 
+    /// @notice update the authorized caller of the validator function
+    /// @param newCaller the new authorized caller of the validator function
+    function setValidatorCaller(address newCaller) external virtual;
+
     /// @inheritdoc Cloneable
     function getComponentInterface() public pure virtual override(AValidator) returns (bytes4) {
         return type(ASignerValidator).interfaceId;

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -50,6 +50,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(defaultOptions, {
         owner: defaultOptions.account.address,
@@ -92,6 +93,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(defaultOptions, {
         owner: defaultOptions.account.address,
@@ -183,6 +185,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(defaultOptions, {
         owner: defaultOptions.account.address,
@@ -242,6 +245,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(defaultOptions, {
         owner: defaultOptions.account.address,
@@ -265,6 +269,7 @@ describe('BoostCore', () => {
       ),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(defaultOptions, {
         owner: defaultOptions.account.address,
@@ -315,6 +320,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(defaultOptions, {
         owner: defaultOptions.account.address,
@@ -391,6 +397,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(defaultOptions, {
         owner: defaultOptions.account.address,
@@ -415,6 +422,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(
         defaultOptions,
@@ -472,6 +480,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(defaultOptions, {
         owner: defaultOptions.account.address,
@@ -490,6 +499,7 @@ describe('BoostCore', () => {
         }),
         validator: new bases.SignerValidator(defaultOptions, {
           signers: [defaultOptions.account.address],
+          validatorCaller: defaultOptions.account.address,
         }),
         allowList: new bases.SimpleAllowList(defaultOptions, {
           owner: defaultOptions.account.address,
@@ -566,6 +576,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(
         defaultOptions,
@@ -757,6 +768,7 @@ describe('BoostCore', () => {
       }),
       validator: new bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address],
+        validatorCaller: defaultOptions.account.address,
       }),
       allowList: new bases.SimpleAllowList(defaultOptions, {
         owner: defaultOptions.account.address,

--- a/packages/sdk/src/BoostCore.ts
+++ b/packages/sdk/src/BoostCore.ts
@@ -101,6 +101,7 @@ import {
   type Target,
   type WriteParams,
   prepareBoostPayload,
+  prepareSignerValidatorPayload,
 } from './utils';
 
 export { boostCoreAbi };
@@ -355,12 +356,28 @@ export class BoostCore extends Deployable<
         isBase: isBase,
         instance: validator.address,
         parameters: isBase
-          ? validator.buildParameters(undefined, options).args.at(0) || zeroHash
+          ? validator
+              .buildParameters(
+                {
+                  signers: [owner],
+                  validatorCaller: coreAddress,
+                },
+                options,
+              )
+              .args.at(0) || zeroHash
           : zeroHash,
       };
     } else {
       validatorPayload.parameters =
-        validator.buildParameters(undefined, options).args.at(0) || zeroHash;
+        validator
+          .buildParameters(
+            {
+              signers: [owner],
+              validatorCaller: coreAddress,
+            },
+            options,
+          )
+          .args.at(0) || zeroHash;
       validatorPayload.instance = validator.base;
     }
 

--- a/packages/sdk/src/Incentives/AllowListIncentive.test.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.test.ts
@@ -78,6 +78,7 @@ describe('AllowListIncentive', () => {
       boostId: boost.id,
     });
 
+    //await boost.validator.setValidatorCaller(boost.assertValidAddress());
     await fixtures.core.claimIncentive(
       boost.id,
       0n,

--- a/packages/sdk/src/Validators/SignerValidator.test.ts
+++ b/packages/sdk/src/Validators/SignerValidator.test.ts
@@ -21,6 +21,7 @@ function freshValidator(fixtures: Fixtures) {
       crypto.randomUUID(),
       new fixtures.bases.SignerValidator(defaultOptions, {
         signers: [defaultOptions.account.address, account],
+        validatorCaller: testAccount.address,
       }),
     );
   };
@@ -34,6 +35,7 @@ describe('SignerValidator', () => {
   test('can successfully be deployed', async () => {
     const action = new SignerValidator(defaultOptions, {
       signers: [testAccount.address],
+      validatorCaller: testAccount.address,
     });
     await action.deploy();
     expect(isAddress(action.assertValidAddress())).toBe(true);

--- a/packages/sdk/src/Validators/SignerValidator.ts
+++ b/packages/sdk/src/Validators/SignerValidator.ts
@@ -3,8 +3,10 @@ import {
   readSignerValidatorSigners,
   signerValidatorAbi,
   simulateSignerValidatorSetAuthorized,
+  simulateSignerValidatorSetValidatorCaller,
   simulateSignerValidatorValidate,
   writeSignerValidatorSetAuthorized,
+  writeSignerValidatorSetValidatorCaller,
   writeSignerValidatorValidate,
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/validators/SignerValidator.sol/SignerValidator.json';
@@ -214,6 +216,34 @@ export class SignerValidator extends DeployableTarget<
     );
     const hash = await writeSignerValidatorSetAuthorized(this._config, request);
     return { hash, result };
+  }
+
+  public async setValidatorCallerRaw(
+    address: Address,
+    params?: WriteParams<typeof signerValidatorAbi, 'setValidatorCaller'>,
+  ) {
+    const { request, result } = await simulateSignerValidatorSetValidatorCaller(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [address],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeSignerValidatorSetValidatorCaller(
+      this._config,
+      request,
+    );
+    return { hash, result };
+  }
+
+  public async setValidatorCaller(
+    address: Address,
+    params?: WriteParams<typeof signerValidatorAbi, 'setValidatorCaller'>,
+  ) {
+    return this.awaitResult(this.setValidatorCallerRaw(address, params));
   }
 
   /**

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -612,6 +612,11 @@ export interface SignerValidatorPayload {
    * @type {Address[]}
    */
   signers: Address[];
+  /**
+   * The authorized caller of the {@link prepareSignerValidator} function
+   * @type {Address}
+   */
+  validatorCaller: Address;
 }
 
 /**
@@ -653,14 +658,19 @@ export interface SignerValidatorValidatePayload {
  *
  * @param {SignerValidatorPayload} param0
  * @param {Address[]} param0.signers
+ * @param {Address} param0.validatorCaller
  * @returns {Hex}
  */
 export const prepareSignerValidatorPayload = ({
   signers,
+  validatorCaller,
 }: SignerValidatorPayload) => {
   return encodeAbiParameters(
-    [{ type: 'address[]', name: 'signers' }],
-    [signers],
+    [
+      { type: 'address[]', name: 'signers' },
+      { type: 'address', name: 'validatorCaller' },
+    ],
+    [signers, validatorCaller],
   );
 };
 

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -95,6 +95,7 @@ export async function freshBoost(
           defaultOptions.account.address,
           accounts.at(0)?.account as Address,
         ],
+        validatorCaller: accounts.at(0)?.account as Address,
       }),
     allowList:
       options.allowList ||


### PR DESCRIPTION
This function call is stateful and an attacker could block others'
claims by calling this maliciously

# merge plan

merge after #44 