### PR TITLE
[BOOST-4580] Event Action Validation

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -4,9 +4,7 @@
   "license": "GPL-3.0-or-later",
   "private": true,
   "type": "module",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "repository": "https://github.com/rabbitholegg/boost-protocol",
   "author": "Boost Team<boost-team@boost.xyz>",
   "access": "public",
@@ -195,6 +193,9 @@
     "test": "vitest dev",
     "test:ci": "CI=true vitest --coverage",
     "typedoc": "npx typedoc"
+  },
+  "dependencies": {
+    "@boostxyz/signatures": "workspace:*"
   },
   "optionalDependencies": {
     "@boostxyz/evm": "workspace:*"

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -8,15 +8,14 @@ import {
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/actions/EventAction.sol/EventAction.json';
 import events from '@boostxyz/signatures/events';
-import {
-  type Abi,
-  type AbiEvent,
-  type AbiItem,
-  type Address,
-  type ContractEventName,
-  type Hex,
-  type Log,
-  getAbiItem,
+import type {
+  Abi,
+  AbiEvent,
+  AbiItem,
+  Address,
+  ContractEventName,
+  Hex,
+  Log,
 } from 'viem';
 import { getLogs } from 'viem/actions';
 import type {

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -7,14 +7,30 @@ import {
   writeEventActionExecute,
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/actions/EventAction.sol/EventAction.json';
-import type { Address, Hex } from 'viem';
+import events from '@boostxyz/signatures/events';
+import {
+  type Abi,
+  type AbiEvent,
+  type AbiItem,
+  type Address,
+  type ContractEventName,
+  type Hex,
+  type Log,
+  getAbiItem,
+} from 'viem';
+import { getLogs } from 'viem/actions';
 import type {
   DeployableOptions,
   GenericDeployableParams,
 } from '../Deployable/Deployable';
 import { DeployableTarget } from '../Deployable/DeployableTarget';
 import {
+  type ActionEvent,
+  type Criteria,
   type EventActionPayload,
+  FilterType,
+  type GetLogsParams,
+  PrimitiveType,
   type ReadParams,
   RegistryType,
   type WriteParams,
@@ -151,6 +167,124 @@ export class EventAction extends DeployableTarget<
     });
     const hash = await writeEventActionExecute(this._config, request);
     return { hash, result };
+  }
+
+  /** Validates all action events
+   * @public
+   * @async
+   * @returns {Promise<boolean>}
+   * @param {?ReadParams<typeof eventActionAbi, 'getActionEvents'>} [params]
+   */
+  public async validateActionEvents(
+    params?: ReadParams<typeof eventActionAbi, 'getActionEvents'> & {
+      knownSignatures?: Record<Hex, AbiItem>;
+    },
+  ) {
+    const actionEvents = await this.getActionEvents(params);
+    for (const actionEvent of actionEvents) {
+      if (!this.isActionEventValid(actionEvent, params)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Validates a single action event
+   * @public
+   * @async
+   * @param {ActionEvent} actionEvent
+   * @returns {boolean}
+   */
+  public async isActionEventValid(
+    actionEvent: ActionEvent,
+    params?: GetLogsParams<Abi, ContractEventName<Abi>> & {
+      knownEvents?: Record<Hex, AbiEvent>;
+    },
+  ) {
+    const criteria = actionEvent.actionParameter;
+    const eventSignature = actionEvent.eventSignature;
+    let event: AbiEvent;
+    // Lookup ABI based on event signature
+    if (params?.knownEvents) {
+      event = params.knownEvents[eventSignature] as AbiEvent;
+    } else {
+      event = (events.abi as Record<Hex, AbiEvent>)[eventSignature] as AbiEvent;
+    }
+    if (!event) {
+      throw new Error(
+        `No known ABI for given event signature: ${eventSignature}`,
+      );
+    }
+    const targetContract = actionEvent.targetContract;
+    // Get all logs matching the event signature from the target contract
+    const logs = await getLogs(
+      this._config.getClient({ chainId: params?.chainId }),
+      {
+        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        ...(params as any),
+        address: targetContract,
+        event,
+      },
+    );
+    for (let log of logs) {
+      if (!this.validateLogAgainstCriteria(criteria, log)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Validates a Viem event log against a given criteria.
+   *
+   * @param {Criteria} criteria - The criteria to validate against.
+   * @param {any[]} log - The Viem event log array.
+   * @returns {boolean} - Returns true if the log passes the criteria, false otherwise.
+   */
+  public async validateLogAgainstCriteria(criteria: Criteria, log: Log) {
+    const fieldValue = log.topics[criteria.fieldIndex];
+    if (fieldValue === undefined) {
+      throw new Error('Field value is undefined');
+    }
+    // Type narrow based on criteria.filterType
+    switch (criteria.filterType) {
+      case FilterType.EQUAL:
+        return fieldValue === criteria.filterData;
+
+      case FilterType.NOT_EQUAL:
+        return fieldValue !== criteria.filterData;
+
+      case FilterType.GREATER_THAN:
+        if (criteria.fieldType === PrimitiveType.UINT) {
+          return BigInt(fieldValue) > BigInt(criteria.filterData);
+        }
+        throw new Error(
+          'GREATER_THAN filter can only be used with UINT fieldType',
+        );
+
+      case FilterType.LESS_THAN:
+        if (criteria.fieldType === PrimitiveType.UINT) {
+          return BigInt(fieldValue) < BigInt(criteria.filterData);
+        }
+        throw new Error(
+          'LESS_THAN filter can only be used with UINT fieldType',
+        );
+
+      case FilterType.CONTAINS:
+        if (
+          criteria.fieldType === PrimitiveType.BYTES ||
+          criteria.fieldType === PrimitiveType.STRING
+        ) {
+          return fieldValue.includes(criteria.filterData);
+        }
+        throw new Error(
+          'CONTAINS filter can only be used with BYTES or STRING fieldType',
+        );
+
+      default:
+        throw new Error('Invalid FilterType provided');
+    }
   }
 
   /**

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -175,9 +175,10 @@ export class EventAction extends DeployableTarget<
    * @param {?ReadParams<typeof eventActionAbi, 'getActionEvents'>} [params]
    */
   public async validateActionEvents(
-    params?: ReadParams<typeof eventActionAbi, 'getActionEvents'> & {
-      knownSignatures?: Record<Hex, AbiItem>;
-    },
+    params?: ReadParams<typeof eventActionAbi, 'getActionEvents'> &
+      GetLogsParams<Abi, ContractEventName<Abi>> & {
+        knownEvents?: Record<Hex, AbiEvent>;
+      },
   ) {
     const actionEvents = await this.getActionEvents(params);
     for (const actionEvent of actionEvents) {

--- a/packages/sdk/src/utils.test.ts
+++ b/packages/sdk/src/utils.test.ts
@@ -5,7 +5,7 @@ import { MockERC20 } from '../test/MockERC20';
 import { defaultOptions } from '../test/helpers';
 import { awaitResult, bytes4, getDeployedContractAddress } from './utils';
 
-describe('bytes4', () => {
+describe.only('bytes4', () => {
   test('should return the bytes4 representation of a string', () => {
     expect(bytes4('0xdeadbeef')).toBe('0xd4fd4e18');
     expect(bytes4('deadbeef')).toBe('0x9f24c52e');

--- a/packages/sdk/src/utils.test.ts
+++ b/packages/sdk/src/utils.test.ts
@@ -5,7 +5,7 @@ import { MockERC20 } from '../test/MockERC20';
 import { defaultOptions } from '../test/helpers';
 import { awaitResult, bytes4, getDeployedContractAddress } from './utils';
 
-describe.only('bytes4', () => {
+describe('bytes4', () => {
   test('should return the bytes4 representation of a string', () => {
     expect(bytes4('0xdeadbeef')).toBe('0xd4fd4e18');
     expect(bytes4('deadbeef')).toBe('0x9f24c52e');

--- a/packages/sdk/vite.config.js
+++ b/packages/sdk/vite.config.js
@@ -19,7 +19,7 @@ const moduleDirectories = Object.keys(packageJson.exports).reduce(
 export default {
   build: {
     rollupOptions: {
-      external: [/^viem/, /^@wagmi(?!.*\/codegen)/],
+      external: [/^viem/, /^@wagmi(?!.*\/codegen)/, /^@boostsdk\/signatures)/],
     },
     lib: {
       entry: Object.keys(packageJson.exports).map((mod) =>

--- a/packages/sdk/vite.config.js
+++ b/packages/sdk/vite.config.js
@@ -19,7 +19,7 @@ const moduleDirectories = Object.keys(packageJson.exports).reduce(
 export default {
   build: {
     rollupOptions: {
-      external: [/^viem/, /^@wagmi(?!.*\/codegen)/, /^@boostsdk\/signatures)/],
+      external: [/^viem/, /^@wagmi(?!.*\/codegen)/, /^@boostxyz\/signatures/],
     },
     lib: {
       entry: Object.keys(packageJson.exports).map((mod) =>

--- a/packages/signatures/build.js
+++ b/packages/signatures/build.js
@@ -1,0 +1,50 @@
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { parseAbiItem, toFunctionSelector } from 'viem';
+import events from './manifests/events.json' with { type: 'json' };
+import functions from './manifests/functions.json' with { type: 'json' };
+
+const index = {
+  events: {
+    abi: {},
+    selectors: {},
+  },
+  functions: {
+    abi: {},
+    selectors: {},
+  },
+};
+
+function addToIndex(type, signature, target) {
+  if (signature.startsWith('//') || signature.startsWith('*')) return;
+  const signatureWithoutType = signature.startsWith(type)
+    ? signature.split(type).at(1).trim()
+    : signature;
+  const itemString = `${type} ${signatureWithoutType}`;
+  const selector = toFunctionSelector(signature);
+  target.abi[selector] = parseAbiItem(itemString);
+  target.selectors[signatureWithoutType] = selector;
+}
+
+for (let signature of events) {
+  addToIndex('event', signature, index.events);
+}
+
+for (let signature of functions) {
+  addToIndex('function', signature, index.functions);
+}
+
+await Promise.all([
+  writeFile(
+    resolve(process.cwd(), './dist/index.json'),
+    JSON.stringify(index, null, 2),
+  ),
+  writeFile(
+    resolve(process.cwd(), './dist/events.json'),
+    JSON.stringify(index.events, null, 2),
+  ),
+  writeFile(
+    resolve(process.cwd(), './dist/functions.json'),
+    JSON.stringify(index.functions, null, 2),
+  ),
+]);

--- a/packages/signatures/manifests/events.json
+++ b/packages/signatures/manifests/events.json
@@ -1,1 +1,4 @@
-["Transfer(address,address,uint256)"]
+[
+  "// Begin common builtin event signatures",
+  "Transfer(address,address,uint256)"
+]

--- a/packages/signatures/manifests/events.json
+++ b/packages/signatures/manifests/events.json
@@ -1,0 +1,1 @@
+["Transfer(address,address,uint256)"]

--- a/packages/signatures/manifests/functions.json
+++ b/packages/signatures/manifests/functions.json
@@ -1,0 +1,1 @@
+["mint(address to, uint256 amount)", "mintPayable(address to, uint256 amount)"]

--- a/packages/signatures/manifests/functions.json
+++ b/packages/signatures/manifests/functions.json
@@ -1,1 +1,5 @@
-["mint(address to, uint256 amount)", "mintPayable(address to, uint256 amount)"]
+[
+  "// Begin common builtin function signatures",
+  "mint(address to, uint256 amount)",
+  "mintPayable(address to, uint256 amount)"
+]

--- a/packages/signatures/package.json
+++ b/packages/signatures/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@boostxyz/signatures",
+  "version": "0.0.0-alpha.0",
+  "description": "An offline database of builtin bytes4 selectors and their corresponding abi items",
+  "repository": "https://github.com/rabbitholegg/boost-protocol",
+  "private": true,
+  "author": "Boost Team<boost-team@boost.xyz>",
+  "type": "module",
+  "files": ["dist"],
+  "main": "dist/index.json",
+  "module": "./dist/index.json",
+  "types": "./dist/index.json",
+  "typings": "./dist/index.json",
+  "sideEffects": false,
+  "license": "GPL-3.0-or-later",
+  "access": "public",
+  "exports": {
+    ".": {
+      "require": "./dist/index.json",
+      "import": "./dist/index.json",
+      "node": "./dist/index.json"
+    },
+    "./events": {
+      "require": "./dist/events.json",
+      "import": "./dist/events.json",
+      "node": "./dist/events.json"
+    },
+    "./functions": {
+      "require": "./dist/functions.json",
+      "import": "./dist/functions.json",
+      "node": "./dist/functions.json"
+    }
+  },
+  "scripts": {
+    "build": "mkdir -p dist && node build.js",
+    "clean": "rm -rf dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
 
   packages/sdk:
     dependencies:
+      '@boostxyz/signatures':
+        specifier: workspace:*
+        version: link:../signatures
       '@wagmi/core':
         specifier: 2.13.0
         version: 2.13.0(react@18.3.0)(typescript@5.3.3)(viem@2.9.27)
@@ -243,6 +246,8 @@ importers:
       '@boostxyz/evm':
         specifier: workspace:*
         version: link:../evm
+
+  packages/signatures: {}
 
 packages:
 

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "artifacts/**", "out/**", "cache/**", ".next/**"]
     },
+    "signatures#build": {
+      "inputs": ["manifests"],
+      "outputs": ["dist/**"]
+    },
     "test": {
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
- create `@boostxyz/signatures` with simple manifests of known function/event signatures
  - at build time, generate their selectors and abi items
- in event action validation, accept `GetLogsParams` and an optional `knownEvents` parameter that can be used instead of `@boostxyz/signatures/events` in case there's an adhoc custom event that isn't yet in the `@boostxyz/signatures` manifests

TODO
- typed errors
- tests