### PR TITLE
chore(evm): refactor Incentive `claim` interface

### DIFF
--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -172,8 +172,7 @@ contract BoostCore is Ownable, ReentrancyGuard {
 
         // wake-disable-next-line reentrancy (false positive, function is nonReentrant)
         if (!boost.validator.validate(boostId_, incentiveId_, claimant, data_)) revert BoostError.Unauthorized();
-        if (!boost.incentives[incentiveId_].claim(abi.encode(Incentive.ClaimPayload({target: claimant, data: data_}))))
-        {
+        if (!boost.incentives[incentiveId_].claim(claimant, data_)) {
             revert BoostError.ClaimFailed(claimant, data_);
         }
     }

--- a/packages/evm/contracts/incentives/AAllowListIncentive.sol
+++ b/packages/evm/contracts/incentives/AAllowListIncentive.sol
@@ -22,13 +22,12 @@ abstract contract AAllowListIncentive is Incentive {
 
     /// @inheritdoc Incentive
     /// @notice Claim a slot on the {SimpleAllowList}
-    /// @param data_ The claim data
-    function claim(bytes calldata data_) external virtual override onlyOwner returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
-        if (claims++ >= limit || claimed[claim_.target]) revert NotClaimable();
-        claimed[claim_.target] = true;
+    /// @param claimTarget the entity receiving the payout
+    function claim(address claimTarget, bytes calldata) external virtual override onlyOwner returns (bool) {
+        if (claims++ >= limit || claimed[claimTarget]) revert NotClaimable();
+        claimed[claimTarget] = true;
 
-        (address[] memory users, bool[] memory allowed) = _makeAllowListPayload(claim_.target);
+        (address[] memory users, bool[] memory allowed) = _makeAllowListPayload(claimTarget);
 
         allowList.setAllowed(users, allowed);
         return true;
@@ -41,9 +40,8 @@ abstract contract AAllowListIncentive is Incentive {
     }
 
     /// @inheritdoc Incentive
-    function isClaimable(bytes calldata data_) external view virtual override returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
-        return claims < limit && !claimed[claim_.target] && !allowList.isAllowed(claim_.target, "");
+    function isClaimable(address claimTarget, bytes calldata) external view virtual override returns (bool) {
+        return claims < limit && !claimed[claimTarget] && !allowList.isAllowed(claimTarget, "");
     }
 
     /// @inheritdoc Incentive

--- a/packages/evm/contracts/incentives/ACGDAIncentive.sol
+++ b/packages/evm/contracts/incentives/ACGDAIncentive.sol
@@ -35,9 +35,8 @@ abstract contract ACGDAIncentive is Incentive {
 
     /// @inheritdoc Incentive
     /// @notice Claim the incentive
-    function claim(bytes calldata data_) external virtual override onlyOwner returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
-        if (!_isClaimable(claim_.target)) revert NotClaimable();
+    function claim(address claimTarget, bytes calldata) external virtual override onlyOwner returns (bool) {
+        if (!_isClaimable(claimTarget)) revert NotClaimable();
         claims++;
 
         // Calculate the current reward and update the state
@@ -47,9 +46,9 @@ abstract contract ACGDAIncentive is Incentive {
             reward > cgdaParams.rewardDecay ? reward - cgdaParams.rewardDecay : cgdaParams.rewardDecay;
 
         // Transfer the reward to the recipient
-        asset.safeTransfer(claim_.target, reward);
+        asset.safeTransfer(claimTarget, reward);
 
-        emit Claimed(claim_.target, abi.encodePacked(asset, claim_.target, reward));
+        emit Claimed(claimTarget, abi.encodePacked(asset, claimTarget, reward));
         return true;
     }
 
@@ -66,9 +65,8 @@ abstract contract ACGDAIncentive is Incentive {
     }
 
     /// @inheritdoc Incentive
-    function isClaimable(bytes calldata data_) external view virtual override returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
-        return _isClaimable(claim_.target);
+    function isClaimable(address claimTarget, bytes calldata) external view virtual override returns (bool) {
+        return _isClaimable(claimTarget);
     }
 
     /// @notice Calculates the current reward based on the time since the last claim.

--- a/packages/evm/contracts/incentives/AERC20Incentive.sol
+++ b/packages/evm/contracts/incentives/AERC20Incentive.sol
@@ -41,26 +41,25 @@ abstract contract AERC20Incentive is Incentive {
     address[] public entries;
 
     /// @notice Claim the incentive
-    /// @param data_ The data payload for the incentive claim `(address recipient, bytes data)`
+    /// @param claimTarget the address receiving the claim
     /// @return True if the incentive was successfully claimed
-    function claim(bytes calldata data_) external override onlyOwner returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
-        if (!_isClaimable(claim_.target)) revert NotClaimable();
+    function claim(address claimTarget, bytes calldata) external override onlyOwner returns (bool) {
+        if (!_isClaimable(claimTarget)) revert NotClaimable();
 
         if (strategy == Strategy.POOL) {
             claims++;
-            claimed[claim_.target] = true;
+            claimed[claimTarget] = true;
 
-            asset.safeTransfer(claim_.target, reward);
+            asset.safeTransfer(claimTarget, reward);
 
-            emit Claimed(claim_.target, abi.encodePacked(asset, claim_.target, reward));
+            emit Claimed(claimTarget, abi.encodePacked(asset, claimTarget, reward));
             return true;
         } else {
             claims++;
-            claimed[claim_.target] = true;
-            entries.push(claim_.target);
+            claimed[claimTarget] = true;
+            entries.push(claimTarget);
 
-            emit Entry(claim_.target);
+            emit Entry(claimTarget);
             return true;
         }
     }
@@ -88,13 +87,12 @@ abstract contract AERC20Incentive is Incentive {
     }
 
     /// @notice Check if an incentive is claimable
-    /// @param data_ The data payload for the claim check `(address recipient, bytes data)`
+    /// @param claimTarget the address that could receive the claim
     /// @return True if the incentive is claimable based on the data payload
     /// @dev For the POOL strategy, the `bytes data` portion of the payload ignored
     /// @dev The recipient must not have already claimed the incentive
-    function isClaimable(bytes calldata data_) public view override returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
-        return _isClaimable(claim_.target);
+    function isClaimable(address claimTarget, bytes calldata) public view override returns (bool) {
+        return _isClaimable(claimTarget);
     }
 
     /// @notice Check if an incentive is claimable for a specific recipient

--- a/packages/evm/contracts/incentives/Incentive.sol
+++ b/packages/evm/contracts/incentives/Incentive.sol
@@ -5,11 +5,12 @@ import {Ownable} from "@solady/auth/Ownable.sol";
 import {ReentrancyGuard} from "@solady/utils/ReentrancyGuard.sol";
 
 import {Cloneable} from "contracts/shared/Cloneable.sol";
+import {IBoostClaim} from "contracts/shared/IBoostClaim.sol";
 
 /// @title Boost Incentive
 /// @notice Abstract contract for a generic Incentive within the Boost protocol
 /// @dev Incentive classes are expected to decode the calldata for implementation-specific handling. If no data is required, calldata should be empty.
-abstract contract Incentive is Ownable, Cloneable, ReentrancyGuard {
+abstract contract Incentive is IBoostClaim, Ownable, Cloneable, ReentrancyGuard {
     /// @notice Emitted when an incentive is claimed
     /// @dev The `data` field contains implementation-specific context. See the implementation's `claim` function for details.
     event Claimed(address indexed recipient, bytes data);
@@ -46,7 +47,7 @@ abstract contract Incentive is Ownable, Cloneable, ReentrancyGuard {
     /// @notice Claim the incentive
     /// @param data_ The data payload for the incentive claim
     /// @return True if the incentive was successfully claimed
-    function claim(bytes calldata data_) external virtual returns (bool);
+    function claim(address claimant, bytes calldata data_) external virtual returns (bool);
 
     /// @notice Reclaim assets from the incentive
     /// @param data_ The data payload for the reclaim
@@ -56,7 +57,7 @@ abstract contract Incentive is Ownable, Cloneable, ReentrancyGuard {
     /// @notice Check if an incentive is claimable
     /// @param data_ The data payload for the claim check (data, signature, etc.)
     /// @return True if the incentive is claimable based on the data payload
-    function isClaimable(bytes calldata data_) external view virtual returns (bool);
+    function isClaimable(address claimant, bytes calldata data_) external view virtual returns (bool);
 
     /// @notice Get the required allowance for the incentive
     /// @param data_ The initialization payload for the incentive

--- a/packages/evm/test/BoostRegistry.t.sol
+++ b/packages/evm/test/BoostRegistry.t.sol
@@ -105,7 +105,7 @@ contract BoostRegistryTest is Test {
     // BoostRegistry.getIdentifier //
     /////////////////////////////////
 
-    function testGetIdentifier() public {
+    function testGetIdentifier() public view {
         assertEq(
             registry.getIdentifier(BoostRegistry.RegistryType.ALLOW_LIST, "SimpleAllowList"),
             SIMPLE_ALLOW_LIST_IDENTIFIER
@@ -118,7 +118,7 @@ contract BoostRegistryTest is Test {
     // BoostRegistry.getCloneIdentifier //
     //////////////////////////////////////
 
-    function testGetCloneIdentifier() public {
+    function testGetCloneIdentifier() public view {
         bytes32 identifier = registry.getCloneIdentifier(
             BoostRegistry.RegistryType.ALLOW_LIST, address(baseAllowListImpl), address(this), "Test AllowList"
         );

--- a/packages/evm/test/budgets/ManagedBudget.t.sol
+++ b/packages/evm/test/budgets/ManagedBudget.t.sol
@@ -44,42 +44,42 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
     // ManagedBudget initial state //
     ////////////////////////////////
 
-    function test_InitialOwner() public {
+    function test_InitialOwner() public view {
         // Ensure the budget has the correct owner
         assertEq(managedBudget.owner(), address(this));
     }
 
-    function test_InitialDistributed() public {
+    function test_InitialDistributed() public view {
         // Ensure the budget has 0 tokens distributed
         assertEq(managedBudget.total(address(mockERC20)), 0);
     }
 
-    function test_InitialDistributed1155() public {
+    function test_InitialDistributed1155() public view {
         // Ensure the budget has 0 of our 1155 tokens distributed
         assertEq(managedBudget.total(address(mockERC1155), 42), 0);
     }
 
-    function test_InitialTotal() public {
+    function test_InitialTotal() public view {
         // Ensure the budget has 0 tokens allocated
         assertEq(managedBudget.total(address(mockERC20)), 0);
     }
 
-    function test_InitialTotal1155() public {
+    function test_InitialTotal1155() public view {
         // Ensure the budget has 0 of our 1155 tokens allocated
         assertEq(managedBudget.total(address(mockERC1155), 42), 0);
     }
 
-    function test_InitialAvailable() public {
+    function test_InitialAvailable() public view {
         // Ensure the budget has 0 tokens available
         assertEq(managedBudget.available(address(mockERC20)), 0);
     }
 
-    function test_InitialAvailable1155() public {
+    function test_InitialAvailable1155() public view {
         // Ensure the budget has 0 of our 1155 tokens available
         assertEq(managedBudget.available(address(mockERC1155), 42), 0);
     }
 
-    function test_InitializerDisabled() public {
+    function test_InitializerDisabled() public view {
         // Because the slot is private, we use `vm.load` to access it then parse out the bits:
         //   - [0] is the `initializing` flag (which should be 0 == false)
         //   - [1..64] hold the `initializedVersion` (which should be 1)
@@ -745,7 +745,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
         assertEq(managedBudget.available(address(0)), 100 ether);
     }
 
-    function testAvailable_NeverAllocated() public {
+    function testAvailable_NeverAllocated() public view {
         // Ensure the budget has 0 tokens available
         assertEq(managedBudget.available(address(otherMockERC20)), 0);
     }
@@ -1028,7 +1028,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
         assertFalse(managedBudget.isAuthorized(address(0xdeadbeef)));
     }
 
-    function testIsAuthorized_Owner() public {
+    function testIsAuthorized_Owner() public view {
         assertTrue(managedBudget.isAuthorized(address(this)));
     }
 
@@ -1036,7 +1036,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
     // ManagedBudget.getComponentInterface //
     ////////////////////////////////////
 
-    function testGetComponentInterface() public {
+    function testGetComponentInterface() public view {
         // Ensure the contract supports the Budget interface
         console.logBytes4(managedBudget.getComponentInterface());
     }
@@ -1045,22 +1045,22 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
     // ManagedBudget.supportsInterface //
     ////////////////////////////////////
 
-    function testSupportsBudgetInterface() public {
+    function testSupportsBudgetInterface() public view {
         // Ensure the contract supports the Budget interface
         assertTrue(managedBudget.supportsInterface(type(Budget).interfaceId));
     }
 
-    function testSupportsERC1155Receiver() public {
+    function testSupportsERC1155Receiver() public view {
         // Ensure the contract supports the Budget interface
         assertTrue(managedBudget.supportsInterface(type(IERC1155Receiver).interfaceId));
     }
 
-    function testSupportsERC165() public {
+    function testSupportsERC165() public view {
         // Ensure the contract supports the Budget interface
         assertTrue(managedBudget.supportsInterface(type(IERC165).interfaceId));
     }
 
-    function testSupportsInterface_NotSupported() public {
+    function testSupportsInterface_NotSupported() public view {
         // Ensure the contract does not support an unsupported interface
         assertFalse(managedBudget.supportsInterface(type(Test).interfaceId));
     }
@@ -1116,9 +1116,9 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
     ////////////////////////////////
 
     function testFallback_NotImplemented() public {
-        // Expect the fallback function to revert with BoostError.NotImplemented
-        vm.expectRevert(BoostError.NotImplemented.selector);
-        address(managedBudget).call{value: 1 ether}("0xdeadbeef");
+        // Expect the fallback function to revert
+        vm.expectRevert();
+        payable(managedBudget).transfer(1 ether);
     }
 
     ///////////////////////////

--- a/packages/evm/test/incentives/AllowListIncentive.t.sol
+++ b/packages/evm/test/incentives/AllowListIncentive.t.sol
@@ -27,7 +27,7 @@ contract AllowListIncentiveTest is Test {
     // Initialization //
     ////////////////////
 
-    function test_initialize() public {
+    function test_initialize() public view {
         assertEq(address(incentive.allowList()), address(allowList));
         assertEq(incentive.limit(), 10);
         assertEq(incentive.owner(), address(this));
@@ -43,53 +43,45 @@ contract AllowListIncentiveTest is Test {
     //////////////////////////////
 
     function test_claim() public {
-        incentive.claim(abi.encode(Incentive.ClaimPayload({target: address(1), data: new bytes(0)})));
+        incentive.claim(address(1), hex"");
         assertEq(allowList.isAllowed(address(1), new bytes(0)), true);
     }
 
     function test_claim_twice() public {
-        incentive.claim(abi.encode(Incentive.ClaimPayload({target: address(1), data: new bytes(0)})));
+        incentive.claim(address(1), hex"");
 
         vm.expectRevert(bytes4(keccak256("NotClaimable()")));
-        incentive.claim(abi.encode(Incentive.ClaimPayload({target: address(1), data: new bytes(0)})));
+        incentive.claim(address(1), hex"");
     }
 
     function test_claim_notOwner() public {
         vm.prank(address(0xdeadbeef));
         vm.expectRevert(bytes4(keccak256("Unauthorized()")));
-        incentive.claim(abi.encode(Incentive.ClaimPayload({target: address(1), data: new bytes(0)})));
+        incentive.claim(address(1), hex"");
     }
 
     function test_claim_maxClaims() public {
         for (uint8 i = 0; i < 10; i++) {
-            incentive.claim(
-                abi.encode(
-                    Incentive.ClaimPayload({target: makeAddr(string(abi.encodePacked("rando", i))), data: new bytes(0)})
-                )
-            );
+            incentive.claim(makeAddr(string(abi.encodePacked("rando", i))), hex"");
         }
         assertEq(incentive.claims(), 10);
 
         vm.expectRevert(bytes4(keccak256("NotClaimable()")));
-        incentive.claim(abi.encode(Incentive.ClaimPayload({target: address(11), data: new bytes(0)})));
+        incentive.claim(address(11), hex"");
     }
 
     ////////////////////////////////////
     // AllowListIncentive.isClaimable //
     ////////////////////////////////////
 
-    function test_isClaimable() public {
-        assertEq(
-            incentive.isClaimable(abi.encode(Incentive.ClaimPayload({target: address(1), data: new bytes(0)}))), true
-        );
+    function test_isClaimable() public view {
+        assertEq(incentive.isClaimable(address(1), hex""), true);
     }
 
     function test_isClaimable_claimed() public {
-        incentive.claim(abi.encode(Incentive.ClaimPayload({target: address(1), data: new bytes(0)})));
+        incentive.claim(address(1), hex"");
 
-        assertEq(
-            incentive.isClaimable(abi.encode(Incentive.ClaimPayload({target: address(1), data: new bytes(0)}))), false
-        );
+        assertEq(incentive.isClaimable(address(1), hex""), false);
     }
 
     ////////////////////////////////
@@ -105,7 +97,7 @@ contract AllowListIncentiveTest is Test {
     // AllowListIncentive.preflight //
     //////////////////////////////////
 
-    function test_preflight() public {
+    function test_preflight() public view {
         assertEq(new bytes(0), incentive.preflight(new bytes(0)));
     }
 
@@ -113,7 +105,7 @@ contract AllowListIncentiveTest is Test {
     // AllowListIncentive.getComponentInterface //
     ////////////////////////////////////
 
-    function testGetComponentInterface() public {
+    function testGetComponentInterface() public view {
         // Retrieve the component interface
         console.logBytes4(incentive.getComponentInterface());
     }
@@ -122,12 +114,12 @@ contract AllowListIncentiveTest is Test {
     // AllowListIncentive.supportsInterface //
     /////////////////////////////////////
 
-    function testSupportsInterface() public {
+    function testSupportsInterface() public view {
         // Ensure the contract supports the Budget interface
         assertTrue(incentive.supportsInterface(type(Incentive).interfaceId));
     }
 
-    function testSupportsInterface_NotSupported() public {
+    function testSupportsInterface_NotSupported() public view {
         // Ensure the contract does not support an unsupported interface
         assertFalse(incentive.supportsInterface(type(Test).interfaceId));
     }

--- a/packages/evm/test/incentives/CGDAIncentive.t.sol
+++ b/packages/evm/test/incentives/CGDAIncentive.t.sol
@@ -133,16 +133,13 @@ contract CGDAIncentiveTest is Test {
 
         address[] memory accounts = _randomAccounts(15);
         for (uint256 i = 0; i < accounts.length; i++) {
-            bytes memory claimPayload = abi.encode(Incentive.ClaimPayload({target: accounts[i], data: bytes("")}));
-            incentive.claim(claimPayload);
+            incentive.claim(accounts[i], hex"");
         }
 
         assertEq(incentive.currentReward(), 0.25 ether);
         assertEq(asset.balanceOf(address(incentive)), 0.25 ether);
 
-        incentive.claim(
-            abi.encode(Incentive.ClaimPayload({target: makeAddr("zach zebra's zootopia"), data: bytes("")}))
-        );
+        incentive.claim(makeAddr("zach zebra's zootopia"), hex"");
 
         assertEq(incentive.currentReward(), 0 ether);
         assertEq(asset.balanceOf(address(incentive)), 0 ether);
@@ -159,9 +156,7 @@ contract CGDAIncentiveTest is Test {
         assertEq(asset.balanceOf(address(incentive)), 0 ether);
 
         vm.expectRevert(Incentive.NotClaimable.selector);
-        incentive.claim(
-            abi.encode(Incentive.ClaimPayload({target: makeAddr("sam's soggy sandwich & soup shack"), data: bytes("")}))
-        );
+        incentive.claim(makeAddr("sam's soggy sandwich & soup shack"), hex"");
 
         assertEq(incentive.currentReward(), 0 ether);
         assertEq(asset.balanceOf(address(incentive)), 0 ether);
@@ -238,8 +233,7 @@ contract CGDAIncentiveTest is Test {
     function test_reclaim() public {
         address[] memory accounts = _randomAccounts(10);
         for (uint256 i = 0; i < accounts.length; i++) {
-            bytes memory claimPayload = abi.encode(Incentive.ClaimPayload({target: accounts[i], data: bytes("")}));
-            incentive.claim(claimPayload);
+            incentive.claim(accounts[i], hex"");
         }
 
         assertEq(incentive.currentReward(), 0.5 ether);
@@ -260,24 +254,21 @@ contract CGDAIncentiveTest is Test {
     function test_isClaimable() public {
         address[] memory accounts = _randomAccounts(15);
         for (uint256 i = 0; i < accounts.length; i++) {
-            bytes memory claimPayload = abi.encode(Incentive.ClaimPayload({target: accounts[i], data: bytes("")}));
-            incentive.claim(claimPayload);
+            incentive.claim(accounts[i], hex"");
         }
 
-        assertEq(incentive.isClaimable(abi.encode(Incentive.ClaimPayload({target: address(1), data: bytes("")}))), true);
+        assertEq(incentive.isClaimable(address(1), hex""), true);
 
-        incentive.claim(abi.encode(Incentive.ClaimPayload({target: address(1), data: bytes("")})));
+        incentive.claim(address(1), hex"");
 
-        assertEq(
-            incentive.isClaimable(abi.encode(Incentive.ClaimPayload({target: address(2), data: bytes("")}))), false
-        );
+        assertEq(incentive.isClaimable(address(2), hex""), false);
     }
 
     /////////////////////////////
     // CGDAIncentive.preflight //
     /////////////////////////////
 
-    function test_preflight() public {
+    function test_preflight() public view {
         bytes memory preflightPayload = incentive.preflight(
             abi.encode(
                 CGDAIncentive.InitPayload({
@@ -301,7 +292,7 @@ contract CGDAIncentiveTest is Test {
     // CGDAIncentive.getComponentInterface //
     ////////////////////////////////////
 
-    function testGetComponentInterface() public {
+    function testGetComponentInterface() public view {
         // Retrieve the component interface
         console.logBytes4(incentive.getComponentInterface());
     }
@@ -310,12 +301,12 @@ contract CGDAIncentiveTest is Test {
     // CGDAIncentive.supportsInterface //
     /////////////////////////////////////
 
-    function testSupportsInterface() public {
+    function testSupportsInterface() public view {
         // Ensure the contract supports the Budget interface
         assertTrue(incentive.supportsInterface(type(Incentive).interfaceId));
     }
 
-    function testSupportsInterface_NotSupported() public {
+    function testSupportsInterface_NotSupported() public view {
         // Ensure the contract does not support an unsupported interface
         assertFalse(incentive.supportsInterface(type(Test).interfaceId));
     }
@@ -325,8 +316,7 @@ contract CGDAIncentiveTest is Test {
     ///////////////////////////
 
     function _makeClaim(address target_) internal {
-        bytes memory claimPayload = abi.encode(Incentive.ClaimPayload({target: target_, data: bytes("")}));
-        incentive.claim(claimPayload);
+        incentive.claim(target_, hex"");
     }
 
     function _makeFungibleTransfer(Budget.AssetType assetType_, address asset_, address target_, uint256 value_)

--- a/packages/evm/test/incentives/ERC1155Incentive.t.sol
+++ b/packages/evm/test/incentives/ERC1155Incentive.t.sol
@@ -89,8 +89,7 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
         );
 
         // Claim the incentive
-        bytes memory claimPayload = abi.encode(Incentive.ClaimPayload({target: address(1), data: bytes("")}));
-        incentive.claim(claimPayload);
+        incentive.claim(address(1), hex"");
 
         // Check the claim status
         assertTrue(incentive.claimed(address(1)));
@@ -101,12 +100,11 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
         _initialize(mockAsset, AERC1155Incentive.Strategy.POOL, 42, 5);
 
         // Claim the incentive on behalf of address(1)
-        bytes memory claimPayload = abi.encode(Incentive.ClaimPayload({target: address(1), data: bytes("")}));
-        incentive.claim(claimPayload);
+        incentive.claim(address(1), hex"");
 
         // Attempt to claim for address(1) again => revert
         vm.expectRevert(Incentive.NotClaimable.selector);
-        incentive.claim(claimPayload);
+        incentive.claim(address(1), hex"");
     }
 
     ////////////////////////////
@@ -147,8 +145,7 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
         _initialize(mockAsset, AERC1155Incentive.Strategy.POOL, 42, 5);
 
         // Check if the incentive is claimable
-        bytes memory claimPayload = abi.encode(Incentive.ClaimPayload({target: address(1), data: bytes("")}));
-        assertTrue(incentive.isClaimable(claimPayload));
+        assertTrue(incentive.isClaimable(address(1), hex""));
     }
 
     function testIsClaimable_AlreadyClaimed() public {
@@ -156,11 +153,10 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
         _initialize(mockAsset, AERC1155Incentive.Strategy.POOL, 42, 5);
 
         // Claim the incentive on behalf of address(1)
-        bytes memory claimPayload = abi.encode(Incentive.ClaimPayload({target: address(1), data: bytes("")}));
-        incentive.claim(claimPayload);
+        incentive.claim(address(1), hex"");
 
         // Check if the incentive is still claimable for address(1) => false
-        assertFalse(incentive.isClaimable(claimPayload));
+        assertFalse(incentive.isClaimable(address(1), hex""));
     }
 
     function testIsClaimable_ExceedsMaxClaims() public {
@@ -170,23 +166,21 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
         // Claim the incentive for 5 different addresses
         address[] memory recipients = _randomAccounts(6);
         for (uint256 i = 0; i < 5; i++) {
-            bytes memory claimPayload = abi.encode(Incentive.ClaimPayload({target: recipients[i], data: bytes("")}));
-            incentive.claim(claimPayload);
+            incentive.claim(recipients[i], hex"");
         }
 
         // Check the claim count
         assertEq(incentive.claims(), 5);
 
         // Check if the incentive is claimable for the 6th address => false
-        bytes memory nextClaimPayload = abi.encode(Incentive.ClaimPayload({target: recipients[5], data: bytes("")}));
-        assertFalse(incentive.isClaimable(nextClaimPayload));
+        assertFalse(incentive.isClaimable(recipients[5], hex""));
     }
 
     //////////////////////////////
     // ERC1155Incentive.preflight //
     //////////////////////////////
 
-    function testPreflight() public {
+    function testPreflight() public view {
         // Check the preflight data
         bytes memory data = incentive.preflight(_initPayload(mockAsset, AERC1155Incentive.Strategy.POOL, 42, 5));
         Budget.Transfer memory budgetRequest = abi.decode(data, (Budget.Transfer));
@@ -199,7 +193,7 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
         assertEq(payload.data, "");
     }
 
-    function testPreflight_WeirdRewards() public {
+    function testPreflight_WeirdRewards() public view {
         // Preflight with zero max claims
         bytes memory noClaims = incentive.preflight(_initPayload(mockAsset, AERC1155Incentive.Strategy.POOL, 42, 0));
         Budget.Transfer memory request = abi.decode(noClaims, (Budget.Transfer));
@@ -211,7 +205,7 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
     // ERC1155Incentive.getComponentInterface //
     ////////////////////////////////////
 
-    function testGetComponentInterface() public {
+    function testGetComponentInterface() public view {
         // Retrieve the component interface
         console.logBytes4(incentive.getComponentInterface());
     }
@@ -220,12 +214,12 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
     // ERC1155Incentive.supportsInterface //
     /////////////////////////////////////
 
-    function testSupportsInterface() public {
+    function testSupportsInterface() public view {
         // Ensure the contract supports the Budget interface
         assertTrue(incentive.supportsInterface(type(Incentive).interfaceId));
     }
 
-    function testSupportsInterface_NotSupported() public {
+    function testSupportsInterface_NotSupported() public view {
         // Ensure the contract does not support an unsupported interface
         assertFalse(incentive.supportsInterface(type(Test).interfaceId));
     }


### PR DESCRIPTION
incentive claim interfaces should contain the claimTarget address as a
parameter since it's more secure and means we have to decode one less
abi bytestring
