### PR TITLE
[BOOST-4637] rename `reclaim` to `clawback`

### DIFF
--- a/packages/evm/contracts/budgets/AManagedBudget.sol
+++ b/packages/evm/contracts/budgets/AManagedBudget.sol
@@ -78,7 +78,7 @@ abstract contract AManagedBudget is Budget, OwnableRoles, IERC1155Receiver, Reen
     /// @dev Only admins can directly reclaim assets from the budget
     /// @dev If the amount is zero, the entire balance of the asset will be transferred to the receiver
     /// @dev If the asset transfer fails, the reclamation will revert
-    function reclaim(bytes calldata data_) external virtual override onlyOwnerOrRoles(ADMIN_ROLE) returns (bool) {
+    function clawback(bytes calldata data_) external virtual override onlyOwnerOrRoles(ADMIN_ROLE) returns (bool) {
         Transfer memory request = abi.decode(data_, (Transfer));
         if (request.assetType == AssetType.ETH || request.assetType == AssetType.ERC20) {
             FungiblePayload memory payload = abi.decode(request.data, (FungiblePayload));

--- a/packages/evm/contracts/budgets/ASimpleBudget.sol
+++ b/packages/evm/contracts/budgets/ASimpleBudget.sol
@@ -81,7 +81,7 @@ abstract contract ASimpleBudget is Budget, IERC1155Receiver, ReentrancyGuard {
     /// @dev Only the owner can directly reclaim assets from the budget
     /// @dev If the amount is zero, the entire balance of the asset will be transferred to the receiver
     /// @dev If the asset transfer fails, the reclamation will revert
-    function reclaim(bytes calldata data_) external virtual override onlyOwner returns (bool) {
+    function clawback(bytes calldata data_) external virtual override onlyOwner returns (bool) {
         Transfer memory request = abi.decode(data_, (Transfer));
         if (request.assetType == AssetType.ETH || request.assetType == AssetType.ERC20) {
             FungiblePayload memory payload = abi.decode(request.data, (FungiblePayload));

--- a/packages/evm/contracts/budgets/AVestingBudget.sol
+++ b/packages/evm/contracts/budgets/AVestingBudget.sol
@@ -81,7 +81,7 @@ abstract contract AVestingBudget is Budget, ReentrancyGuard {
     /// @dev Only the owner can directly reclaim assets from the budget, and this action is not subject to the vesting schedule
     /// @dev If the amount is zero, the entire available balance of the asset will be transferred to the receiver
     /// @dev If the asset transfer fails for any reason, the function will revert
-    function reclaim(bytes calldata data_) external virtual override onlyOwner returns (bool) {
+    function clawback(bytes calldata data_) external virtual override onlyOwner returns (bool) {
         Transfer memory request = abi.decode(data_, (Transfer));
         if (request.assetType == AssetType.ETH || request.assetType == AssetType.ERC20) {
             FungiblePayload memory payload = abi.decode(request.data, (FungiblePayload));

--- a/packages/evm/contracts/budgets/Budget.sol
+++ b/packages/evm/contracts/budgets/Budget.sol
@@ -78,7 +78,7 @@ abstract contract Budget is Ownable, Cloneable, Receiver {
     /// @notice Reclaim assets from the budget
     /// @param data_ The compressed data for the reclamation (amount, token address, token ID, etc.)
     /// @return True if the reclamation was successful
-    function reclaim(bytes calldata data_) external virtual returns (bool);
+    function clawback(bytes calldata data_) external virtual returns (bool);
 
     /// @notice Disburse assets from the budget to a single recipient
     /// @param data_ The compressed {Transfer} request

--- a/packages/evm/contracts/incentives/AAllowListIncentive.sol
+++ b/packages/evm/contracts/incentives/AAllowListIncentive.sol
@@ -35,7 +35,7 @@ abstract contract AAllowListIncentive is Incentive {
 
     /// @inheritdoc Incentive
     /// @dev Not a valid operation for this type of incentive
-    function reclaim(bytes calldata) external pure override returns (bool) {
+    function clawback(bytes calldata) external pure override returns (bool) {
         revert BoostError.NotImplemented();
     }
 

--- a/packages/evm/contracts/incentives/ACGDAIncentive.sol
+++ b/packages/evm/contracts/incentives/ACGDAIncentive.sol
@@ -53,8 +53,8 @@ abstract contract ACGDAIncentive is Incentive {
     }
 
     /// @inheritdoc Incentive
-    function reclaim(bytes calldata data_) external virtual override onlyOwner returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
+    function clawback(bytes calldata data_) external virtual override onlyOwner returns (bool) {
+        ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 
         // Transfer the tokens back to the intended recipient

--- a/packages/evm/contracts/incentives/AERC1155Incentive.sol
+++ b/packages/evm/contracts/incentives/AERC1155Incentive.sol
@@ -61,8 +61,8 @@ abstract contract AERC1155Incentive is Incentive, IERC1155Receiver {
     }
 
     /// @inheritdoc Incentive
-    function reclaim(bytes calldata data_) external override onlyOwner returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
+    function clawback(bytes calldata data_) external override onlyOwner returns (bool) {
+        ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 
         // Ensure the amount is valid and reduce the max claims accordingly

--- a/packages/evm/contracts/incentives/AERC20Incentive.sol
+++ b/packages/evm/contracts/incentives/AERC20Incentive.sol
@@ -65,8 +65,8 @@ abstract contract AERC20Incentive is Incentive {
     }
 
     /// @inheritdoc Incentive
-    function reclaim(bytes calldata data_) external override onlyOwner returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
+    function clawback(bytes calldata data_) external override onlyOwner returns (bool) {
+        ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 
         if (strategy == Strategy.RAFFLE) {

--- a/packages/evm/contracts/incentives/APointsIncentive.sol
+++ b/packages/evm/contracts/incentives/APointsIncentive.sol
@@ -48,7 +48,7 @@ abstract contract APointsIncentive is Incentive {
 
     /// @inheritdoc Incentive
     /// @dev Not a valid operation for this type of incentive
-    function reclaim(bytes calldata) external pure override returns (bool) {
+    function clawback(bytes calldata) external pure override returns (bool) {
         revert BoostError.NotImplemented();
     }
 

--- a/packages/evm/contracts/incentives/ERC20VariableIncentive.sol
+++ b/packages/evm/contracts/incentives/ERC20VariableIncentive.sol
@@ -95,8 +95,8 @@ contract ERC20VariableIncentive is Incentive {
     }
 
     /// @inheritdoc Incentive
-    function reclaim(bytes calldata data_) external override onlyOwner returns (bool) {
-        ClaimPayload memory claim_ = abi.decode(data_, (ClaimPayload));
+    function clawback(bytes calldata data_) external override onlyOwner returns (bool) {
+        ClawbackPayload memory claim_ = abi.decode(data_, (ClawbackPayload));
         (uint256 amount) = abi.decode(claim_.data, (uint256));
 
         limit -= amount;

--- a/packages/evm/contracts/incentives/Incentive.sol
+++ b/packages/evm/contracts/incentives/Incentive.sol
@@ -24,7 +24,7 @@ abstract contract Incentive is IBoostClaim, Ownable, Cloneable, ReentrancyGuard 
     /// @notice A struct representing the payload for an incentive claim
     /// @param target The address of the recipient
     /// @param data The implementation-specific data for the claim, if needed
-    struct ClaimPayload {
+    struct ClawbackPayload {
         address target;
         bytes data;
     }
@@ -52,7 +52,7 @@ abstract contract Incentive is IBoostClaim, Ownable, Cloneable, ReentrancyGuard 
     /// @notice Reclaim assets from the incentive
     /// @param data_ The data payload for the reclaim
     /// @return True if the assets were successfully reclaimed
-    function reclaim(bytes calldata data_) external virtual returns (bool);
+    function clawback(bytes calldata data_) external virtual returns (bool);
 
     /// @notice Check if an incentive is claimable
     /// @param data_ The data payload for the claim check (data, signature, etc.)

--- a/packages/evm/test/budgets/ManagedBudget.t.sol
+++ b/packages/evm/test/budgets/ManagedBudget.t.sol
@@ -219,7 +219,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
 
         // Reclaim 99 tokens from the budget
         data = _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), 99 ether);
-        assertTrue(managedBudget.reclaim(data));
+        assertTrue(managedBudget.clawback(data));
 
         // Ensure the budget has 1 token left
         assertEq(managedBudget.available(address(mockERC20)), 1 ether);
@@ -233,7 +233,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
 
         // Reclaim 99 ETH from the budget
         data = _makeFungibleTransfer(Budget.AssetType.ETH, address(0), address(1), 99 ether);
-        assertTrue(managedBudget.reclaim(data));
+        assertTrue(managedBudget.clawback(data));
 
         // Ensure the budget has 1 ETH left
         assertEq(managedBudget.available(address(0)), 1 ether);
@@ -264,7 +264,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
                 data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 99, data: ""}))
             })
         );
-        assertTrue(managedBudget.reclaim(data));
+        assertTrue(managedBudget.clawback(data));
 
         // Ensure the budget has 1 of token ID 42 left
         assertEq(managedBudget.available(address(mockERC1155), 42), 1);
@@ -281,7 +281,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
 
         // Reclaim all tokens from the budget
         data = _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), 0);
-        assertTrue(managedBudget.reclaim(data));
+        assertTrue(managedBudget.clawback(data));
 
         // Ensure the budget has no tokens left
         assertEq(managedBudget.available(address(mockERC20)), 0 ether);
@@ -301,7 +301,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
         vm.expectRevert(
             abi.encodeWithSelector(Budget.TransferFailed.selector, address(mockERC20), address(0), uint256(100 ether))
         );
-        managedBudget.reclaim(data);
+        managedBudget.clawback(data);
 
         // Ensure the budget has 100 tokens
         assertEq(managedBudget.available(address(mockERC20)), 100 ether);
@@ -323,7 +323,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
                 Budget.InsufficientFunds.selector, address(mockERC20), uint256(100 ether), uint256(101 ether)
             )
         );
-        managedBudget.reclaim(data);
+        managedBudget.clawback(data);
     }
 
     function testReclaim_ImproperData() public {
@@ -340,7 +340,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
         // with improperly encoded data
         data = abi.encodePacked(mockERC20, uint256(100 ether));
         vm.expectRevert();
-        managedBudget.reclaim(data);
+        managedBudget.clawback(data);
     }
 
     function testReclaim_NotOwner() public {
@@ -356,7 +356,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
         // We can reuse the data from above because the target is `address(this)` in both cases
         vm.prank(address(1));
         vm.expectRevert();
-        managedBudget.reclaim(data);
+        managedBudget.clawback(data);
     }
 
     function testReclaim_Manager() public {
@@ -378,7 +378,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
         // We can reuse the data from above because the target is `address(this)` in both cases
         vm.prank(address(0xdeadbeef));
         vm.expectRevert();
-        managedBudget.reclaim(data);
+        managedBudget.clawback(data);
     }
 
     function testReclaim_Admin() public {
@@ -399,7 +399,7 @@ contract ManagedBudgetTest is Test, IERC1155Receiver {
         // Try to reclaim 100 tokens from the budget as a non-owner
         // We can reuse the data from above because the target is `address(this)` in both cases
         vm.prank(address(0xdeadbeef));
-        managedBudget.reclaim(data);
+        managedBudget.clawback(data);
     }
 
     ///////////////////////////

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -215,7 +215,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
 
         // Reclaim 99 tokens from the budget
         data = _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), 99 ether);
-        assertTrue(simpleBudget.reclaim(data));
+        assertTrue(simpleBudget.clawback(data));
 
         // Ensure the budget has 1 token left
         assertEq(simpleBudget.available(address(mockERC20)), 1 ether);
@@ -229,7 +229,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
 
         // Reclaim 99 ETH from the budget
         data = _makeFungibleTransfer(Budget.AssetType.ETH, address(0), address(1), 99 ether);
-        assertTrue(simpleBudget.reclaim(data));
+        assertTrue(simpleBudget.clawback(data));
 
         // Ensure the budget has 1 ETH left
         assertEq(simpleBudget.available(address(0)), 1 ether);
@@ -260,7 +260,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
                 data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 99, data: ""}))
             })
         );
-        assertTrue(simpleBudget.reclaim(data));
+        assertTrue(simpleBudget.clawback(data));
 
         // Ensure the budget has 1 of token ID 42 left
         assertEq(simpleBudget.available(address(mockERC1155), 42), 1);
@@ -277,7 +277,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
 
         // Reclaim all tokens from the budget
         data = _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), 0);
-        assertTrue(simpleBudget.reclaim(data));
+        assertTrue(simpleBudget.clawback(data));
 
         // Ensure the budget has no tokens left
         assertEq(simpleBudget.available(address(mockERC20)), 0 ether);
@@ -297,7 +297,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         vm.expectRevert(
             abi.encodeWithSelector(Budget.TransferFailed.selector, address(mockERC20), address(0), uint256(100 ether))
         );
-        simpleBudget.reclaim(data);
+        simpleBudget.clawback(data);
 
         // Ensure the budget has 100 tokens
         assertEq(simpleBudget.available(address(mockERC20)), 100 ether);
@@ -319,7 +319,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
                 Budget.InsufficientFunds.selector, address(mockERC20), uint256(100 ether), uint256(101 ether)
             )
         );
-        simpleBudget.reclaim(data);
+        simpleBudget.clawback(data);
     }
 
     function testReclaim_ImproperData() public {
@@ -336,7 +336,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         // with improperly encoded data
         data = abi.encodePacked(mockERC20, uint256(100 ether));
         vm.expectRevert();
-        simpleBudget.reclaim(data);
+        simpleBudget.clawback(data);
     }
 
     function testReclaim_NotOwner() public {
@@ -352,7 +352,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         // We can reuse the data from above because the target is `address(this)` in both cases
         vm.prank(address(1));
         vm.expectRevert();
-        simpleBudget.reclaim(data);
+        simpleBudget.clawback(data);
     }
 
     ///////////////////////////

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -188,7 +188,7 @@ contract VestingBudgetTest is Test {
 
         // Reclaim 99 tokens from the budget
         assertTrue(
-            vestingBudget.reclaim(
+            vestingBudget.clawback(
                 _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), 99 ether)
             )
         );
@@ -207,7 +207,7 @@ contract VestingBudgetTest is Test {
 
         // Reclaim 99 ETH from the budget
         bytes memory data = _makeFungibleTransfer(Budget.AssetType.ETH, address(0), address(1), 99 ether);
-        assertTrue(vestingBudget.reclaim(data));
+        assertTrue(vestingBudget.clawback(data));
 
         // Ensure the budget has 1 ETH left
         assertEq(vestingBudget.available(address(0)), 1 ether);
@@ -219,7 +219,7 @@ contract VestingBudgetTest is Test {
 
         // Reclaim all tokens from the budget
         bytes memory data = _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), 0);
-        assertTrue(vestingBudget.reclaim(data));
+        assertTrue(vestingBudget.clawback(data));
 
         // Ensure the budget has no tokens left
         assertEq(vestingBudget.available(address(mockERC20)), 0 ether);
@@ -234,7 +234,7 @@ contract VestingBudgetTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(Budget.TransferFailed.selector, address(mockERC20), address(0), uint256(100 ether))
         );
-        vestingBudget.reclaim(data);
+        vestingBudget.clawback(data);
 
         // Ensure the budget has 100 tokens
         assertEq(vestingBudget.available(address(mockERC20)), 100 ether);
@@ -251,7 +251,7 @@ contract VestingBudgetTest is Test {
                 Budget.InsufficientFunds.selector, address(mockERC20), uint256(100 ether), uint256(101 ether)
             )
         );
-        vestingBudget.reclaim(data);
+        vestingBudget.clawback(data);
     }
 
     function testReclaim_ImproperData() public {
@@ -268,7 +268,7 @@ contract VestingBudgetTest is Test {
         // with uncompressed but properly encoded data
         data = abi.encodePacked(mockERC20, uint256(100 ether), address(this));
         vm.expectRevert();
-        vestingBudget.reclaim(data);
+        vestingBudget.clawback(data);
     }
 
     function testReclaim_NotOwner() public {
@@ -278,7 +278,7 @@ contract VestingBudgetTest is Test {
         // We can reuse the data from above because the target is `address(this)` in both cases
         vm.prank(address(1));
         vm.expectRevert();
-        vestingBudget.reclaim(
+        vestingBudget.clawback(
             _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), 100 ether)
         );
     }

--- a/packages/evm/test/incentives/AllowListIncentive.t.sol
+++ b/packages/evm/test/incentives/AllowListIncentive.t.sol
@@ -88,9 +88,9 @@ contract AllowListIncentiveTest is Test {
     // AllowListIncentive.reclaim //
     ////////////////////////////////
 
-    function test_reclaim() public {
+    function test_clawback() public {
         vm.expectRevert(bytes4(keccak256("NotImplemented()")));
-        incentive.reclaim(new bytes(0));
+        incentive.clawback(new bytes(0));
     }
 
     //////////////////////////////////

--- a/packages/evm/test/incentives/CGDAIncentive.t.sol
+++ b/packages/evm/test/incentives/CGDAIncentive.t.sol
@@ -146,9 +146,12 @@ contract CGDAIncentiveTest is Test {
     }
 
     function test_claim_OutOfBudget() public {
-        incentive.reclaim(
+        incentive.clawback(
             abi.encode(
-                Incentive.ClaimPayload({target: makeAddr("weird al's wonky waffle house"), data: abi.encode(10 ether)})
+                Incentive.ClawbackPayload({
+                    target: makeAddr("weird al's wonky waffle house"),
+                    data: abi.encode(10 ether)
+                })
             )
         );
 
@@ -230,7 +233,7 @@ contract CGDAIncentiveTest is Test {
     // CGDAIncentive.reclaim //
     ///////////////////////////
 
-    function test_reclaim() public {
+    function test_clawback() public {
         address[] memory accounts = _randomAccounts(10);
         for (uint256 i = 0; i < accounts.length; i++) {
             incentive.claim(accounts[i], hex"");
@@ -240,8 +243,8 @@ contract CGDAIncentiveTest is Test {
         assertEq(asset.balanceOf(address(incentive)), 2.25 ether);
 
         bytes memory reclaimPayload =
-            abi.encode(Incentive.ClaimPayload({target: address(0xdeadbeef), data: abi.encode(2 ether)}));
-        incentive.reclaim(reclaimPayload);
+            abi.encode(Incentive.ClawbackPayload({target: address(0xdeadbeef), data: abi.encode(2 ether)}));
+        incentive.clawback(reclaimPayload);
 
         assertEq(incentive.currentReward(), 0.25 ether);
         assertEq(asset.balanceOf(address(incentive)), 0.25 ether);

--- a/packages/evm/test/incentives/ERC1155Incentive.t.sol
+++ b/packages/evm/test/incentives/ERC1155Incentive.t.sol
@@ -117,8 +117,8 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
         assertEq(incentive.limit(), 100);
 
         // Reclaim 50x the reward amount
-        bytes memory reclaimPayload = abi.encode(Incentive.ClaimPayload({target: address(1), data: abi.encode(50)}));
-        incentive.reclaim(reclaimPayload);
+        bytes memory reclaimPayload = abi.encode(Incentive.ClawbackPayload({target: address(1), data: abi.encode(50)}));
+        incentive.clawback(reclaimPayload);
         assertEq(mockAsset.balanceOf(address(1), 42), 50);
 
         // Check that enough assets remain to cover 50 more claims
@@ -131,9 +131,9 @@ contract ERC1155IncentiveTest is Test, IERC1155Receiver {
         _initialize(mockAsset, AERC1155Incentive.Strategy.POOL, 42, 100);
 
         // Reclaim 101 tokens => exceeds balance => revert
-        bytes memory reclaimPayload = abi.encode(Incentive.ClaimPayload({target: address(1), data: abi.encode(101)}));
+        bytes memory reclaimPayload = abi.encode(Incentive.ClawbackPayload({target: address(1), data: abi.encode(101)}));
         vm.expectRevert(abi.encodeWithSelector(BoostError.ClaimFailed.selector, address(this), reclaimPayload));
-        incentive.reclaim(reclaimPayload);
+        incentive.clawback(reclaimPayload);
     }
 
     ////////////////////////////////

--- a/packages/evm/test/incentives/ERC20Incentive.t.sol
+++ b/packages/evm/test/incentives/ERC20Incentive.t.sol
@@ -123,8 +123,8 @@ contract ERC20IncentiveTest is Test {
 
         // Reclaim 50x the reward amount
         bytes memory reclaimPayload =
-            abi.encode(Incentive.ClaimPayload({target: address(1), data: abi.encode(50 ether)}));
-        incentive.reclaim(reclaimPayload);
+            abi.encode(Incentive.ClawbackPayload({target: address(1), data: abi.encode(50 ether)}));
+        incentive.clawback(reclaimPayload);
         assertEq(mockAsset.balanceOf(address(1)), 50 ether);
 
         // Check that enough assets remain to cover 50 more claims
@@ -138,9 +138,9 @@ contract ERC20IncentiveTest is Test {
 
         // Reclaim 50.1x => not an integer multiple of the reward amount => revert
         bytes memory reclaimPayload =
-            abi.encode(Incentive.ClaimPayload({target: address(1), data: abi.encode(50.1 ether)}));
+            abi.encode(Incentive.ClawbackPayload({target: address(1), data: abi.encode(50.1 ether)}));
         vm.expectRevert(abi.encodeWithSelector(BoostError.ClaimFailed.selector, address(this), reclaimPayload));
-        incentive.reclaim(reclaimPayload);
+        incentive.clawback(reclaimPayload);
     }
 
     function testReclaim_RaffleStrategy() public {
@@ -155,10 +155,10 @@ contract ERC20IncentiveTest is Test {
 
         // Attempt to reclaim the reward => revert (because the reward is now locked)
         bytes memory reclaimPayload =
-            abi.encode(Incentive.ClaimPayload({target: address(1), data: abi.encode(100 ether)}));
+            abi.encode(Incentive.ClawbackPayload({target: address(1), data: abi.encode(100 ether)}));
 
         vm.expectRevert(abi.encodeWithSelector(BoostError.ClaimFailed.selector, address(this), reclaimPayload));
-        incentive.reclaim(reclaimPayload);
+        incentive.clawback(reclaimPayload);
         assertEq(incentive.limit(), 5);
     }
 
@@ -168,8 +168,8 @@ contract ERC20IncentiveTest is Test {
 
         // Reclaim the full reward amount
         bytes memory reclaimPayload =
-            abi.encode(Incentive.ClaimPayload({target: address(this), data: abi.encode(100 ether)}));
-        incentive.reclaim(reclaimPayload);
+            abi.encode(Incentive.ClawbackPayload({target: address(this), data: abi.encode(100 ether)}));
+        incentive.clawback(reclaimPayload);
 
         // Check that the limit is set to 0
         assertEq(incentive.limit(), 0);

--- a/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
@@ -112,7 +112,6 @@ contract ERC20VariableIncentiveTest is Test {
         _initialize(address(mockAsset), 1 ether, 1 ether);
 
         // Claim the incentive
-        abi.encode(Incentive.ClaimPayload({target: CLAIM_RECIPIENT, data: abi.encode(1 ether)}));
         incentive.claim(CLAIM_RECIPIENT, _encodeBoostClaim(1 ether));
 
         // Attempt to claim again => revert
@@ -145,8 +144,8 @@ contract ERC20VariableIncentiveTest is Test {
 
         // Reclaim some tokens
         bytes memory reclaimPayload =
-            abi.encode(Incentive.ClaimPayload({target: address(this), data: abi.encode(2 ether)}));
-        incentive.reclaim(reclaimPayload);
+            abi.encode(Incentive.ClawbackPayload({target: address(this), data: abi.encode(2 ether)}));
+        incentive.clawback(reclaimPayload);
 
         // Check the balance and limit
         assertEq(mockAsset.balanceOf(address(this)), 2 ether);

--- a/packages/evm/test/incentives/PointsIncentive.t.sol
+++ b/packages/evm/test/incentives/PointsIncentive.t.sol
@@ -170,9 +170,9 @@ contract PointsIncentiveTest is Test {
     // PointsIncentive.reclaim //
     /////////////////////////////
 
-    function test_reclaim() public {
+    function test_clawback() public {
         vm.expectRevert(BoostError.NotImplemented.selector);
-        incentive.reclaim(new bytes(0));
+        incentive.clawback(new bytes(0));
     }
 
     ////////////////////////////////////

--- a/packages/sdk/src/Budgets/SimpleBudget.ts
+++ b/packages/sdk/src/Budgets/SimpleBudget.ts
@@ -6,14 +6,14 @@ import {
   readSimpleBudgetTotal,
   simpleBudgetAbi,
   simulateSimpleBudgetAllocate,
+  simulateSimpleBudgetClawback,
   simulateSimpleBudgetDisburse,
   simulateSimpleBudgetDisburseBatch,
-  simulateSimpleBudgetReclaim,
   simulateSimpleBudgetSetAuthorized,
   writeSimpleBudgetAllocate,
+  writeSimpleBudgetClawback,
   writeSimpleBudgetDisburse,
   writeSimpleBudgetDisburseBatch,
-  writeSimpleBudgetReclaim,
   writeSimpleBudgetSetAuthorized,
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/budgets/SimpleBudget.sol/SimpleBudget.json';
@@ -192,41 +192,41 @@ export class SimpleBudget extends DeployableTarget<
   }
 
   /**
-   * Reclaims assets from the budget.
-   * Only the owner can directly reclaim assets from the budget
+   * Clawbacks assets from the budget.
+   * Only the owner can directly clawback assets from the budget
    * If the amount is zero, the entire balance of the asset will be transferred to the receiver
    * If the asset transfer fails, the reclamation will revert
    *
    * @public
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
-   * @param {?WriteParams<typeof simpleBudgetAbi, 'reclaim'>} [params]
+   * @param {?WriteParams<typeof simpleBudgetAbi, 'clawback'>} [params]
    * @returns {Promise<boolean>} - True if the request was successful
    */
-  public async reclaim(
+  public async clawback(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
-    params?: WriteParams<typeof simpleBudgetAbi, 'reclaim'>,
+    params?: WriteParams<typeof simpleBudgetAbi, 'clawback'>,
   ) {
-    return this.awaitResult(this.reclaimRaw(transfer, params));
+    return this.awaitResult(this.clawbackRaw(transfer, params));
   }
 
   /**
-   * Reclaims assets from the budget.
-   * Only the owner can directly reclaim assets from the budget
+   * Clawbacks assets from the budget.
+   * Only the owner can directly clawback assets from the budget
    * If the amount is zero, the entire balance of the asset will be transferred to the receiver
    * If the asset transfer fails, the reclamation will revert
    *
    * @public
    * @async
    * @param {(FungibleTransferPayload | ERC1155TransferPayload)} transfer
-   * @param {?WriteParams<typeof simpleBudgetAbi, 'reclaim'>} [params]
+   * @param {?WriteParams<typeof simpleBudgetAbi, 'clawback'>} [params]
    * @returns {Promise<boolean>} - True if the request was successful
    */
-  public async reclaimRaw(
+  public async clawbackRaw(
     transfer: FungibleTransferPayload | ERC1155TransferPayload,
-    params?: WriteParams<typeof simpleBudgetAbi, 'reclaim'>,
+    params?: WriteParams<typeof simpleBudgetAbi, 'clawback'>,
   ) {
-    const { request, result } = await simulateSimpleBudgetReclaim(
+    const { request, result } = await simulateSimpleBudgetClawback(
       this._config,
       {
         address: this.assertValidAddress(),
@@ -236,7 +236,7 @@ export class SimpleBudget extends DeployableTarget<
         ...(params as any),
       },
     );
-    const hash = await writeSimpleBudgetReclaim(this._config, request);
+    const hash = await writeSimpleBudgetClawback(this._config, request);
     return { hash, result };
   }
 

--- a/packages/sdk/src/Budgets/VestingBudget.ts
+++ b/packages/sdk/src/Budgets/VestingBudget.ts
@@ -9,15 +9,15 @@ import {
   readVestingBudgetStart,
   readVestingBudgetTotal,
   simulateVestingBudgetAllocate,
+  simulateVestingBudgetClawback,
   simulateVestingBudgetDisburse,
   simulateVestingBudgetDisburseBatch,
-  simulateVestingBudgetReclaim,
   simulateVestingBudgetSetAuthorized,
   vestingBudgetAbi,
   writeVestingBudgetAllocate,
+  writeVestingBudgetClawback,
   writeVestingBudgetDisburse,
   writeVestingBudgetDisburseBatch,
-  writeVestingBudgetReclaim,
   writeVestingBudgetSetAuthorized,
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/budgets/VestingBudget.sol/VestingBudget.json';
@@ -69,7 +69,7 @@ export type VestingBudgetLog<
  * - The budget is designed to manage native and ERC20 token balances only. Using rebasing tokens or other non-standard token types may result in unexpected behavior.
  * - Any assets allocated to this type of budget will follow the vesting schedule as if they were locked from the beginning, which is to say that, if the vesting has already started, some portion of the assets will be immediately available for distribution.
  * - A vesting budget can also act as a time-lock, unlocking all assets at a specified point in time. To release assets at a specific time rather than vesting them over time, set the `start` to the desired time and the `duration` to zero.
- * - This contract is {Ownable} to enable the owner to allocate to the budget, reclaim and disburse assets from the budget, and to set authorized addresses. Additionally, the owner can transfer ownership of the budget to another address. Doing so has no effect on the vesting schedule.
+ * - This contract is {Ownable} to enable the owner to allocate to the budget, clawback and disburse assets from the budget, and to set authorized addresses. Additionally, the owner can transfer ownership of the budget to another address. Doing so has no effect on the vesting schedule.
  *
  * @export
  * @class VestingBudget
@@ -211,41 +211,41 @@ export class VestingBudget extends DeployableTarget<
   }
 
   /**
-   * Reclaims assets from the budget.
-   * Only the owner can directly reclaim assets from the budget
+   * Clawbacks assets from the budget.
+   * Only the owner can directly clawback assets from the budget
    * If the amount is zero, the entire balance of the asset will be transferred to the receiver
    * If the asset transfer fails, the reclamation will revert
    *
    * @public
    * @async
    * @param {(FungibleTransferPayload)} transfer
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'reclaim'>} [params]
+   * @param {?WriteParams<typeof vestingBudgetAbi, 'clawback'>} [params]
    * @returns {Promise<boolean>} - True if the request was successful
    */
-  public async reclaim(
+  public async clawback(
     transfer: FungibleTransferPayload,
-    params?: WriteParams<typeof vestingBudgetAbi, 'reclaim'>,
+    params?: WriteParams<typeof vestingBudgetAbi, 'clawback'>,
   ) {
-    return this.awaitResult(this.reclaimRaw(transfer, params));
+    return this.awaitResult(this.clawbackRaw(transfer, params));
   }
 
   /**
-   * Reclaims assets from the budget.
-   * Only the owner can directly reclaim assets from the budget
+   * Clawbacks assets from the budget.
+   * Only the owner can directly clawback assets from the budget
    * If the amount is zero, the entire balance of the asset will be transferred to the receiver
    * If the asset transfer fails, the reclamation will revert
    *
    * @public
    * @async
    * @param {(FungibleTransferPayload)} transfer
-   * @param {?WriteParams<typeof vestingBudgetAbi, 'reclaim'>} [params]
+   * @param {?WriteParams<typeof vestingBudgetAbi, 'clawback'>} [params]
    * @returns {Promise<boolean>} - True if the request was successful
    */
-  public async reclaimRaw(
+  public async clawbackRaw(
     transfer: FungibleTransferPayload,
-    params?: WriteParams<typeof vestingBudgetAbi, 'reclaim'>,
+    params?: WriteParams<typeof vestingBudgetAbi, 'clawback'>,
   ) {
-    const { request, result } = await simulateVestingBudgetReclaim(
+    const { request, result } = await simulateVestingBudgetClawback(
       this._config,
       {
         address: this.assertValidAddress(),
@@ -255,7 +255,7 @@ export class VestingBudget extends DeployableTarget<
         ...(params as any),
       },
     );
-    const hash = await writeVestingBudgetReclaim(this._config, request);
+    const hash = await writeVestingBudgetClawback(this._config, request);
     return { hash, result };
   }
 

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -10,9 +10,9 @@ import {
   readCgdaIncentiveReward,
   readCgdaIncentiveTotalBudget,
   simulateCgdaIncentiveClaim,
-  simulateCgdaIncentiveReclaim,
+  simulateCgdaIncentiveClawback,
   writeCgdaIncentiveClaim,
-  writeCgdaIncentiveReclaim,
+  writeCgdaIncentiveClawback,
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/incentives/CGDAIncentive.sol/CGDAIncentive.json';
 import type { Address, ContractEventName, Hex } from 'viem';
@@ -255,35 +255,35 @@ export class CGDAIncentive extends DeployableTarget<
   }
 
   /**
-   * Reclaim assets from the incentive
+   * Clawback assets from the incentive
    *
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof cgdaIncentiveAbi, 'reclaim'>} [params]
-   * @returns {Promise<boolean>} -  True if the assets were successfully reclaimed
+   * @param {?WriteParams<typeof cgdaIncentiveAbi, 'clawback'>} [params]
+   * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
-  public async reclaim(
+  public async clawback(
     payload: ClaimPayload,
-    params?: WriteParams<typeof cgdaIncentiveAbi, 'reclaim'>,
+    params?: WriteParams<typeof cgdaIncentiveAbi, 'clawback'>,
   ) {
-    return this.awaitResult(this.reclaimRaw(payload, params));
+    return this.awaitResult(this.clawbackRaw(payload, params));
   }
 
   /**
-   * Reclaim assets from the incentive
+   * Clawback assets from the incentive
    *
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof cgdaIncentiveAbi, 'reclaim'>} [params]
-   * @returns {Promise<boolean>} -  True if the assets were successfully reclaimed
+   * @param {?WriteParams<typeof cgdaIncentiveAbi, 'clawback'>} [params]
+   * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
-  public async reclaimRaw(
+  public async clawbackRaw(
     payload: ClaimPayload,
-    params?: WriteParams<typeof cgdaIncentiveAbi, 'reclaim'>,
+    params?: WriteParams<typeof cgdaIncentiveAbi, 'clawback'>,
   ) {
-    const { request, result } = await simulateCgdaIncentiveReclaim(
+    const { request, result } = await simulateCgdaIncentiveClawback(
       this._config,
       {
         address: this.assertValidAddress(),
@@ -293,7 +293,7 @@ export class CGDAIncentive extends DeployableTarget<
         ...(params as any),
       },
     );
-    const hash = await writeCgdaIncentiveReclaim(this._config, request);
+    const hash = await writeCgdaIncentiveClawback(this._config, request);
     return { hash, result };
   }
 

--- a/packages/sdk/src/Incentives/ERC1155Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC1155Incentive.ts
@@ -11,9 +11,9 @@ import {
   readErc1155IncentiveStrategy,
   readErc1155IncentiveTokenId,
   simulateErc1155IncentiveClaim,
-  simulateErc1155IncentiveReclaim,
+  simulateErc1155IncentiveClawback,
   writeErc1155IncentiveClaim,
-  writeErc1155IncentiveReclaim,
+  writeErc1155IncentiveClawback,
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/incentives/ERC1155Incentive.sol/ERC1155Incentive.json';
 import type { Address, ContractEventName, Hex } from 'viem';
@@ -279,14 +279,14 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc1155IncentiveAbi, 'reclaim'>} [params]
+   * @param {?WriteParams<typeof erc1155IncentiveAbi, 'clawback'>} [params]
    * @returns {unknown}
    */
-  public async reclaim(
+  public async clawback(
     payload: ClaimPayload,
-    params?: WriteParams<typeof erc1155IncentiveAbi, 'reclaim'>,
+    params?: WriteParams<typeof erc1155IncentiveAbi, 'clawback'>,
   ) {
-    return this.awaitResult(this.reclaimRaw(payload, params));
+    return this.awaitResult(this.clawbackRaw(payload, params));
   }
 
   /**
@@ -295,14 +295,14 @@ export class ERC1155Incentive extends DeployableTarget<
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc1155IncentiveAbi, 'reclaim'>} [params]
+   * @param {?WriteParams<typeof erc1155IncentiveAbi, 'clawback'>} [params]
    * @returns {unknown}
    */
-  public async reclaimRaw(
+  public async clawbackRaw(
     payload: ClaimPayload,
-    params?: WriteParams<typeof erc1155IncentiveAbi, 'reclaim'>,
+    params?: WriteParams<typeof erc1155IncentiveAbi, 'clawback'>,
   ) {
-    const { request, result } = await simulateErc1155IncentiveReclaim(
+    const { request, result } = await simulateErc1155IncentiveClawback(
       this._config,
       {
         address: this.assertValidAddress(),
@@ -312,7 +312,7 @@ export class ERC1155Incentive extends DeployableTarget<
         ...(params as any),
       },
     );
-    const hash = await writeErc1155IncentiveReclaim(this._config, request);
+    const hash = await writeErc1155IncentiveClawback(this._config, request);
     return { hash, result };
   }
 

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -11,11 +11,11 @@ import {
   readErc20IncentiveReward,
   readErc20IncentiveStrategy,
   simulateErc20IncentiveClaim,
+  simulateErc20IncentiveClawback,
   simulateErc20IncentiveDrawRaffle,
-  simulateErc20IncentiveReclaim,
   writeErc20IncentiveClaim,
+  writeErc20IncentiveClawback,
   writeErc20IncentiveDrawRaffle,
-  writeErc20IncentiveReclaim,
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/incentives/ERC20Incentive.sol/ERC20Incentive.json';
 import type { Address, ContractEventName, Hex } from 'viem';
@@ -290,35 +290,35 @@ export class ERC20Incentive extends DeployableTarget<
   }
 
   /**
-   * Reclaim assets from the incentive
+   * Clawback assets from the incentive
    *
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20IncentiveAbi, 'reclaim'>} [params]
-   * @returns {Promise<boolean>} -  True if the assets were successfully reclaimed
+   * @param {?WriteParams<typeof erc20IncentiveAbi, 'clawback'>} [params]
+   * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
-  public async reclaim(
+  public async clawback(
     payload: ClaimPayload,
-    params?: WriteParams<typeof erc20IncentiveAbi, 'reclaim'>,
+    params?: WriteParams<typeof erc20IncentiveAbi, 'clawback'>,
   ) {
-    return this.awaitResult(this.reclaimRaw(payload, params));
+    return this.awaitResult(this.clawbackRaw(payload, params));
   }
 
   /**
-   * Reclaim assets from the incentive
+   * Clawback assets from the incentive
    *
    * @public
    * @async
    * @param {ClaimPayload} payload
-   * @param {?WriteParams<typeof erc20IncentiveAbi, 'reclaim'>} [params]
-   * @returns {Promise<boolean>} -  True if the assets were successfully reclaimed
+   * @param {?WriteParams<typeof erc20IncentiveAbi, 'clawback'>} [params]
+   * @returns {Promise<boolean>} -  True if the assets were successfully clawbacked
    */
-  public async reclaimRaw(
+  public async clawbackRaw(
     payload: ClaimPayload,
-    params?: WriteParams<typeof erc20IncentiveAbi, 'reclaim'>,
+    params?: WriteParams<typeof erc20IncentiveAbi, 'clawback'>,
   ) {
-    const { request, result } = await simulateErc20IncentiveReclaim(
+    const { request, result } = await simulateErc20IncentiveClawback(
       this._config,
       {
         address: this.assertValidAddress(),
@@ -328,7 +328,7 @@ export class ERC20Incentive extends DeployableTarget<
         ...(params as any),
       },
     );
-    const hash = await writeErc20IncentiveReclaim(this._config, request);
+    const hash = await writeErc20IncentiveClawback(this._config, request);
     return { hash, result };
   }
 


### PR DESCRIPTION
`reclaim` can be conflated with `claim`, so `clawback` is a more distinctly
helpful name.
