### PR TITLE
[BOOST-4614]: test(evm): Increase SimpleBudget Coverage

### DIFF
--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -207,13 +207,8 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         mockERC1155.setApprovalForAll(address(simpleBudget), true);
 
         // Prepare allocation data
-        bytes memory allocateData = _makeERC1155Transfer(
-            address(mockERC1155),
-            address(this),
-            tokenId,
-            initialAmount,
-            ""
-        );
+        bytes memory allocateData =
+            _makeERC1155Transfer(address(mockERC1155), address(this), tokenId, initialAmount, "");
 
         // Set up the mock to manipulate the balance after transfer
         vm.mockCall(

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -625,19 +625,19 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         assertEq(mockERC1155.balanceOf(address(simpleBudget), tokenId), amount);
 
         // Disburse the tokens to the zero address
-        bytes memory disburseData = abi.encode(Budget.Transfer({
-            assetType: Budget.AssetType.ERC1155,
-            asset: token,
-            target: address(0),
-            data: abi.encode(Budget.ERC1155Payload({
-                tokenId: tokenId,
-                amount: amount,
-                data: ""
-            }))
-        }));
+        bytes memory disburseData = abi.encode(
+            Budget.Transfer({
+                assetType: Budget.AssetType.ERC1155,
+                asset: token,
+                target: address(0),
+                data: abi.encode(Budget.ERC1155Payload({tokenId: tokenId, amount: amount, data: ""}))
+            })
+        );
 
         // Expect the disbursement to fail
-        vm.expectRevert(abi.encodeWithSelector(Budget.TransferFailed.selector, address(mockERC1155), address(0), amount));
+        vm.expectRevert(
+            abi.encodeWithSelector(Budget.TransferFailed.selector, address(mockERC1155), address(0), amount)
+        );
         simpleBudget.disburse(disburseData);
 
         // Ensure the budget still has 10 tokens
@@ -924,11 +924,11 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
     function testOnERC1155Received() public view {
         // Call onERC1155Received with dummy values
         bytes4 result = simpleBudget.onERC1155Received(
-            address(0xc0ffee),   // operator
+            address(0xc0ffee), // operator
             address(0xdeadbeef), // from
-            1,                   // id
-            1,                   // amount
-            ""                   // data
+            1, // id
+            1, // amount
+            "" // data
         );
 
         // Check if it returns the correct selector
@@ -938,19 +938,15 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
     function testOnERC1155BatchReceived() public view {
         // Call onERC1155BatchReceived with dummy values
         bytes4 result = simpleBudget.onERC1155BatchReceived(
-            address(0xc0ffee),   // operator
+            address(0xc0ffee), // operator
             address(0xdeadbeef), // from
-            new uint256[](1),    // ids
-            new uint256[](1),    // amounts
-            ""                   // data
+            new uint256[](1), // ids
+            new uint256[](1), // amounts
+            "" // data
         );
 
         // Check if it returns the correct selector
-        assertEq(
-            result,
-            IERC1155Receiver.onERC1155BatchReceived.selector,
-            "Should return correct selector"
-        );
+        assertEq(result, IERC1155Receiver.onERC1155BatchReceived.selector, "Should return correct selector");
     }
 
     ///////////////////////////

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -904,6 +904,24 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         assertEq(result, IERC1155Receiver.onERC1155Received.selector, "Should return correct selector");
     }
 
+    function testOnERC1155BatchReceived() public view {
+        // Call onERC1155BatchReceived with dummy values
+        bytes4 result = simpleBudget.onERC1155BatchReceived(
+            address(0xc0ffee),   // operator
+            address(0xdeadbeef), // from
+            new uint256[](1),    // ids
+            new uint256[](1),    // amounts
+            ""                   // data
+        );
+
+        // Check if it returns the correct selector
+        assertEq(
+            result,
+            IERC1155Receiver.onERC1155BatchReceived.selector,
+            "Should return correct selector"
+        );
+    }
+
     ///////////////////////////
     // Test Helper Functions //
     ///////////////////////////

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -250,10 +250,10 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
     }
 
     ///////////////////////////
-    // SimpleBudget.reclaim  //
+    // SimpleBudget.clawback //
     ///////////////////////////
 
-    function testReclaim() public {
+    function testClawback() public {
         // Approve the budget to transfer tokens
         mockERC20.approve(address(simpleBudget), 100 ether);
 
@@ -270,7 +270,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         assertEq(simpleBudget.available(address(mockERC20)), 1 ether);
     }
 
-    function testReclaim_NativeBalance() public {
+    function testClawback_NativeBalance() public {
         // Allocate 100 ETH to the budget
         bytes memory data = _makeFungibleTransfer(ABudget.AssetType.ETH, address(0), address(this), 100 ether);
         simpleBudget.allocate{value: 100 ether}(data);
@@ -284,7 +284,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         assertEq(simpleBudget.available(address(0)), 1 ether);
     }
 
-    function testReclaim_ERC1155() public {
+    function testClawback_ERC1155() public {
         // Approve the budget to transfer tokens
         mockERC1155.setApprovalForAll(address(simpleBudget), true);
 
@@ -315,7 +315,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         assertEq(simpleBudget.available(address(mockERC1155), 42), 1);
     }
 
-    function testReclaim_ZeroAmount() public {
+    function testClawback_ZeroAmount() public {
         // Approve the budget to transfer tokens
         mockERC20.approve(address(simpleBudget), 100 ether);
 
@@ -332,7 +332,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         assertEq(simpleBudget.available(address(mockERC20)), 0 ether);
     }
 
-    function testReclaim_ZeroAddress() public {
+    function testClawback_ZeroAddress() public {
         // Approve the budget to transfer tokens
         mockERC20.approve(address(simpleBudget), 100 ether);
 
@@ -352,7 +352,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         assertEq(simpleBudget.available(address(mockERC20)), 100 ether);
     }
 
-    function testReclaim_InsufficientFunds() public {
+    function testClawback_InsufficientFunds() public {
         // Approve the budget to transfer tokens
         mockERC20.approve(address(simpleBudget), 100 ether);
 
@@ -371,7 +371,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         simpleBudget.clawback(data);
     }
 
-    function testReclaim_ImproperData() public {
+    function testClawback_ImproperData() public {
         bytes memory data;
 
         // Approve the budget to transfer tokens
@@ -388,7 +388,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         simpleBudget.clawback(data);
     }
 
-    function testReclaim_NotOwner() public {
+    function testClawback_NotOwner() public {
         // Approve the budget to transfer tokens
         mockERC20.approve(address(simpleBudget), 100 ether);
 

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -381,9 +381,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         );
 
         // Expect the InsufficientFunds revert
-        vm.expectRevert(
-            abi.encodeWithSelector(Budget.InsufficientFunds.selector, address(mockERC1155), 100, 101)
-        );
+        vm.expectRevert(abi.encodeWithSelector(Budget.InsufficientFunds.selector, address(mockERC1155), 100, 101));
         simpleBudget.clawback(clawbackData);
     }
 

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -513,7 +513,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
             Budget.Transfer({
                 assetType: Budget.AssetType.ERC1155,
                 asset: address(mockERC1155),
-                target: address(0),
+                target: address(0xC0ffee),
                 data: abi.encode(Budget.ERC1155Payload({tokenId: tokenId, amount: disburseAmount, data: ""}))
             })
         );

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -219,7 +219,6 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         vm.expectRevert(abi.encodeWithSelector(Budget.InvalidAllocation.selector, address(mockERC20), amount));
         simpleBudget.allocate(data);
 
-        // Clear the mock to avoid affecting other tests
         vm.clearMockedCalls();
     }
 
@@ -245,7 +244,6 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         vm.expectRevert(abi.encodeWithSelector(Budget.InvalidAllocation.selector, address(mockERC1155), initialAmount));
         simpleBudget.allocate(allocateData);
 
-        // Clear the mock to avoid affecting other tests
         vm.clearMockedCalls();
     }
 

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -605,9 +605,8 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         );
         simpleBudget.disburse(disburseData);
 
-        // Verify balances haven't changed
+        // Verify balance of budget hasn't changed
         assertEq(mockERC1155.balanceOf(address(simpleBudget), tokenId), initialAmount);
-        assertEq(mockERC1155.balanceOf(address(0xdead), tokenId), 0);
     }
 
     function testDisburse_ImproperData() public {

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -890,6 +890,20 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         assertEq(simpleBudget.available(address(0)), 1 ether);
     }
 
+    function testOnERC1155Received() public view {
+        // Call onERC1155Received with dummy values
+        bytes4 result = simpleBudget.onERC1155Received(
+            address(0xc0ffee),   // operator
+            address(0xdeadbeef), // from
+            1,                   // id
+            1,                   // amount
+            ""                   // data
+        );
+
+        // Check if it returns the correct selector
+        assertEq(result, IERC1155Receiver.onERC1155Received.selector, "Should return correct selector");
+    }
+
     ///////////////////////////
     // Test Helper Functions //
     ///////////////////////////

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -577,9 +577,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         // Disburse 101 tokens from the budget to the recipient
         data = _makeERC1155Transfer(address(mockERC1155), address(1), 42, 101, bytes(""));
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Budget.InsufficientFunds.selector, address(mockERC1155), uint256(100), uint256(101)
-            )
+            abi.encodeWithSelector(Budget.InsufficientFunds.selector, address(mockERC1155), uint256(100), uint256(101))
         );
         simpleBudget.disburse(data);
     }

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -206,7 +206,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         mockERC20.approve(address(simpleBudget), amount);
 
         // Transfer 100 tokens to the budget
-        bytes memory data = _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), amount);
+        bytes memory data = _makeFungibleTransfer(ABudget.AssetType.ERC20, address(mockERC20), address(this), amount);
 
         // Set up the mock to manipulate the balance after transfer
         vm.mockCall(
@@ -216,7 +216,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         );
 
         // Expect revert due to InvalidAllocation
-        vm.expectRevert(abi.encodeWithSelector(Budget.InvalidAllocation.selector, address(mockERC20), amount));
+        vm.expectRevert(abi.encodeWithSelector(ABudget.InvalidAllocation.selector, address(mockERC20), amount));
         simpleBudget.allocate(data);
 
         vm.clearMockedCalls();
@@ -241,7 +241,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         );
 
         // Expect revert due to InvalidAllocation
-        vm.expectRevert(abi.encodeWithSelector(Budget.InvalidAllocation.selector, address(mockERC1155), initialAmount));
+        vm.expectRevert(abi.encodeWithSelector(ABudget.InvalidAllocation.selector, address(mockERC1155), initialAmount));
         simpleBudget.allocate(allocateData);
 
         vm.clearMockedCalls();
@@ -408,11 +408,11 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
 
         // Allocate 100 of token ID 42 to the budget
         bytes memory data = abi.encode(
-            Budget.Transfer({
-                assetType: Budget.AssetType.ERC1155,
+            ABudget.Transfer({
+                assetType: ABudget.AssetType.ERC1155,
                 asset: address(mockERC1155),
                 target: address(this),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 100, data: ""}))
+                data: abi.encode(ABudget.ERC1155Payload({tokenId: 42, amount: 100, data: ""}))
             })
         );
         simpleBudget.allocate(data);
@@ -420,16 +420,16 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
 
         // Attempt to clawback more than available
         bytes memory clawbackData = abi.encode(
-            Budget.Transfer({
-                assetType: Budget.AssetType.ERC1155,
+            ABudget.Transfer({
+                assetType: ABudget.AssetType.ERC1155,
                 asset: address(mockERC1155),
                 target: address(this),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 101, data: ""}))
+                data: abi.encode(ABudget.ERC1155Payload({tokenId: 42, amount: 101, data: ""}))
             })
         );
 
         // Expect the InsufficientFunds revert
-        vm.expectRevert(abi.encodeWithSelector(Budget.InsufficientFunds.selector, address(mockERC1155), 100, 101));
+        vm.expectRevert(abi.encodeWithSelector(ABudget.InsufficientFunds.selector, address(mockERC1155), 100, 101));
         simpleBudget.clawback(clawbackData);
     }
 
@@ -577,7 +577,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         // Disburse 101 tokens from the budget to the recipient
         data = _makeERC1155Transfer(address(mockERC1155), address(1), 42, 101, bytes(""));
         vm.expectRevert(
-            abi.encodeWithSelector(Budget.InsufficientFunds.selector, address(mockERC1155), uint256(100), uint256(101))
+            abi.encodeWithSelector(ABudget.InsufficientFunds.selector, address(mockERC1155), uint256(100), uint256(101))
         );
         simpleBudget.disburse(data);
     }
@@ -677,17 +677,17 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
 
         // Disburse the tokens to the zero address
         bytes memory disburseData = abi.encode(
-            Budget.Transfer({
-                assetType: Budget.AssetType.ERC1155,
+            ABudget.Transfer({
+                assetType: ABudget.AssetType.ERC1155,
                 asset: token,
                 target: address(0),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: tokenId, amount: amount, data: ""}))
+                data: abi.encode(ABudget.ERC1155Payload({tokenId: tokenId, amount: amount, data: ""}))
             })
         );
 
         // Expect the disbursement to fail
         vm.expectRevert(
-            abi.encodeWithSelector(Budget.TransferFailed.selector, address(mockERC1155), address(0), amount)
+            abi.encodeWithSelector(ABudget.TransferFailed.selector, address(mockERC1155), address(0), amount)
         );
         simpleBudget.disburse(disburseData);
 

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -566,47 +566,22 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
     }
 
     function testDisburse_InsufficientFundsERC1155() public {
-        uint256 tokenId = 42;
-        uint256 initialAmount = 100;
-        uint256 disburseAmount = 101; // More than available
-
         // Approve the budget to transfer tokens
         mockERC1155.setApprovalForAll(address(simpleBudget), true);
 
-        // Allocate tokens to the budget
-        bytes memory allocateData = abi.encode(
-            Budget.Transfer({
-                assetType: Budget.AssetType.ERC1155,
-                asset: address(mockERC1155),
-                target: address(this),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: tokenId, amount: initialAmount, data: ""}))
-            })
-        );
-        simpleBudget.allocate(allocateData);
+        // Allocate 100 tokens to the budget
+        bytes memory data = _makeERC1155Transfer(address(mockERC1155), address(this), 42, 100, bytes(""));
+        simpleBudget.allocate(data);
+        assertEq(simpleBudget.total(address(mockERC1155), 42), 100);
 
-        // Verify allocation
-        assertEq(mockERC1155.balanceOf(address(simpleBudget), tokenId), initialAmount);
-
-        // Attempt to disburse more than available
-        bytes memory disburseData = abi.encode(
-            Budget.Transfer({
-                assetType: Budget.AssetType.ERC1155,
-                asset: address(mockERC1155),
-                target: address(0xC0ffee),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: tokenId, amount: disburseAmount, data: ""}))
-            })
-        );
-
-        // Expect the InsufficientFunds revert
+        // Disburse 101 tokens from the budget to the recipient
+        data = _makeERC1155Transfer(address(mockERC1155), address(1), 42, 101, bytes(""));
         vm.expectRevert(
             abi.encodeWithSelector(
-                Budget.InsufficientFunds.selector, address(mockERC1155), initialAmount, disburseAmount
+                Budget.InsufficientFunds.selector, address(mockERC1155), uint256(100), uint256(101)
             )
         );
-        simpleBudget.disburse(disburseData);
-
-        // Verify balance of budget hasn't changed
-        assertEq(mockERC1155.balanceOf(address(simpleBudget), tokenId), initialAmount);
+        simpleBudget.disburse(data);
     }
 
     function testDisburse_ImproperData() public {

--- a/packages/evm/test/budgets/SimpleBudget.t.sol
+++ b/packages/evm/test/budgets/SimpleBudget.t.sol
@@ -402,7 +402,7 @@ contract SimpleBudgetTest is Test, IERC1155Receiver {
         simpleBudget.clawback(data);
     }
 
-    function testClawback_ERC1155InsufficientFunds() public {
+    function testClawback_InsufficientFundsERC1155() public {
         // Approve the budget to transfer tokens
         mockERC1155.setApprovalForAll(address(simpleBudget), true);
 


### PR DESCRIPTION
I was only able to get the coverage up to 94%.

There is one line which is the `reconcile` function. This simple function just returns `0`, and is present in the test cases. However, due to a bug? with the coverage tool, it does not get considered as covered. You need to do something like this for it to be considered covered.
```
    function reconcile(bytes calldata) external virtual override returns (uint256) {
        uint256 zero = 0;
        return zero;
    }
```

https://github.com/rabbitholegg/boost-protocol/blob/f02171710699539c1ae6382081b8d3b0ffe0ede1/packages/evm/contracts/budgets/ASimpleBudget.sol#L222-L224


The rest of the uncovered lines are for unsupported asset types. Im not able to figure out a way trigger these conditions. I feel like I have tried everything, including manipulating the raw calldata and passing it into the relevant functions. Since assetType is an enum, trying to use a value that is not in the enum fails. No idea how to get around this.


- https://github.com/rabbitholegg/boost-protocol/blob/f02171710699539c1ae6382081b8d3b0ffe0ede1/packages/evm/contracts/budgets/ASimpleBudget.sol#L71
- https://github.com/rabbitholegg/boost-protocol/blob/f02171710699539c1ae6382081b8d3b0ffe0ede1/packages/evm/contracts/budgets/ASimpleBudget.sol#L101
- https://github.com/rabbitholegg/boost-protocol/blob/f02171710699539c1ae6382081b8d3b0ffe0ede1/packages/evm/contracts/budgets/ASimpleBudget.sol#L133