### PR TITLE
[BOOST-4615]: test(evm): Increase VestingBudget Coverage 

### DIFF
--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -602,6 +602,17 @@ contract VestingBudgetTest is Test {
         vestingBudget.setAuthorized(accounts, authorized);
     }
 
+    ///////////////////////
+    // VestingBudget.end //
+    ///////////////////////
+
+    function testEnd() public view {
+        uint256 expectedEnd = vestingBudget.start() + vestingBudget.duration();
+        uint256 actualEnd = vestingBudget.end();
+        
+        assertEq(actualEnd, expectedEnd, "End time should equal start + duration");
+    }
+
     ////////////////////////////////
     // VestingBudget.isAuthorized //
     ////////////////////////////////

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -7,7 +7,9 @@ import {Initializable} from "@solady/utils/Initializable.sol";
 import {LibClone} from "@solady/utils/LibClone.sol";
 import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
 
-import {MockERC20} from "contracts/shared/Mocks.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/interfaces/IERC1155Receiver.sol";
+
+import {MockERC20, MockERC1155} from "contracts/shared/Mocks.sol";
 import {BoostError} from "contracts/shared/BoostError.sol";
 import {ABudget} from "contracts/budgets/ABudget.sol";
 import {ACloneable} from "contracts/shared/ACloneable.sol";
@@ -16,12 +18,17 @@ import {VestingBudget} from "contracts/budgets/VestingBudget.sol";
 contract VestingBudgetTest is Test {
     MockERC20 mockERC20;
     MockERC20 otherMockERC20;
+    MockERC1155 mockERC1155;
     VestingBudget vestingBudget;
 
     function setUp() public {
         // Deploy a new ERC20 contract and mint 100 tokens
         mockERC20 = new MockERC20();
         mockERC20.mint(address(this), 100 ether);
+
+        // Deploy a new ERC1155 contract and mint 100 of token ID 42
+        mockERC1155 = new MockERC1155();
+        mockERC1155.mint(address(this), 42, 100);
 
         // Deploy a new VestingBudget contract and initialize it
         vestingBudget = VestingBudget(payable(LibClone.clone(address(new VestingBudget()))));
@@ -727,5 +734,13 @@ contract VestingBudgetTest is Test {
         }
 
         return abi.encode(transfer);
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155Received.selector;
     }
 }

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -31,8 +31,8 @@ contract VestingBudgetTest is Test {
                     owner: address(this),
                     authorized: new address[](0),
                     start: uint64(block.timestamp),
-                    duration: uint64(1 days),
-                    cliff: 0
+                    duration: uint64(10 days),
+                    cliff: 1 days
                 })
             )
         );

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -9,7 +9,7 @@ import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
 
 import {IERC1155Receiver} from "@openzeppelin/contracts/interfaces/IERC1155Receiver.sol";
 
-import {MockERC20, MockERC1155} from "contracts/shared/Mocks.sol";
+import {MockERC20} from "contracts/shared/Mocks.sol";
 import {BoostError} from "contracts/shared/BoostError.sol";
 import {ABudget} from "contracts/budgets/ABudget.sol";
 import {ACloneable} from "contracts/shared/ACloneable.sol";
@@ -18,17 +18,12 @@ import {VestingBudget} from "contracts/budgets/VestingBudget.sol";
 contract VestingBudgetTest is Test {
     MockERC20 mockERC20;
     MockERC20 otherMockERC20;
-    MockERC1155 mockERC1155;
     VestingBudget vestingBudget;
 
     function setUp() public {
         // Deploy a new ERC20 contract and mint 100 tokens
         mockERC20 = new MockERC20();
         mockERC20.mint(address(this), 100 ether);
-
-        // Deploy a new ERC1155 contract and mint 100 of token ID 42
-        mockERC1155 = new MockERC1155();
-        mockERC1155.mint(address(this), 42, 100);
 
         // Deploy a new VestingBudget contract and initialize it
         vestingBudget = VestingBudget(payable(LibClone.clone(address(new VestingBudget()))));
@@ -213,9 +208,9 @@ contract VestingBudgetTest is Test {
         bytes memory erc1155Data = abi.encode(
             Budget.Transfer({
                 assetType: Budget.AssetType.ERC1155,
-                asset: address(mockERC1155),
+                asset: address(0xC0ffEe),
                 target: address(this),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 100, data: ""}))
+                data: abi.encode(Budget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
             })
         );
 
@@ -335,9 +330,9 @@ contract VestingBudgetTest is Test {
         bytes memory erc1155Data = abi.encode(
             Budget.Transfer({
                 assetType: Budget.AssetType.ERC1155,
-                asset: address(mockERC1155),
+                asset: address(0xC0ffEe),
                 target: address(this),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 100, data: ""}))
+                data: abi.encode(Budget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
             })
         );
 
@@ -500,9 +495,9 @@ contract VestingBudgetTest is Test {
         bytes memory erc1155Data = abi.encode(
             Budget.Transfer({
                 assetType: Budget.AssetType.ERC1155,
-                asset: address(mockERC1155),
+                asset: address(0xC0ffEe),
                 target: address(this),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 100, data: ""}))
+                data: abi.encode(Budget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
             })
         );
 

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -9,7 +9,7 @@ import {SafeTransferLib} from "@solady/utils/SafeTransferLib.sol";
 
 import {IERC1155Receiver} from "@openzeppelin/contracts/interfaces/IERC1155Receiver.sol";
 
-import {MockERC20} from "contracts/shared/Mocks.sol";
+import {MockERC20, MockERC1155} from "contracts/shared/Mocks.sol";
 import {BoostError} from "contracts/shared/BoostError.sol";
 import {ABudget} from "contracts/budgets/ABudget.sol";
 import {ACloneable} from "contracts/shared/ACloneable.sol";
@@ -18,12 +18,16 @@ import {VestingBudget} from "contracts/budgets/VestingBudget.sol";
 contract VestingBudgetTest is Test {
     MockERC20 mockERC20;
     MockERC20 otherMockERC20;
+    MockERC1155 mockERC1155;
     VestingBudget vestingBudget;
 
     function setUp() public {
         // Deploy a new ERC20 contract and mint 100 tokens
         mockERC20 = new MockERC20();
         mockERC20.mint(address(this), 100 ether);
+
+        // Deploy a new ERC1155 contract
+        mockERC1155 = new MockERC1155();
 
         // Deploy a new VestingBudget contract and initialize it
         vestingBudget = VestingBudget(payable(LibClone.clone(address(new VestingBudget()))));
@@ -208,7 +212,7 @@ contract VestingBudgetTest is Test {
         bytes memory erc1155Data = abi.encode(
             Budget.Transfer({
                 assetType: Budget.AssetType.ERC1155,
-                asset: address(0xC0ffEe),
+                asset: address(mockERC1155),
                 target: address(this),
                 data: abi.encode(Budget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
             })
@@ -330,7 +334,7 @@ contract VestingBudgetTest is Test {
         bytes memory erc1155Data = abi.encode(
             Budget.Transfer({
                 assetType: Budget.AssetType.ERC1155,
-                asset: address(0xC0ffEe),
+                asset: address(mockERC1155),
                 target: address(this),
                 data: abi.encode(Budget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
             })
@@ -495,7 +499,7 @@ contract VestingBudgetTest is Test {
         bytes memory erc1155Data = abi.encode(
             Budget.Transfer({
                 assetType: Budget.AssetType.ERC1155,
-                asset: address(0xC0ffEe),
+                asset: address(mockERC1155),
                 target: address(this),
                 data: abi.encode(Budget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
             })

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -180,7 +180,7 @@ contract VestingBudgetTest is Test {
 
         // Prepare allocation data
         bytes memory allocateData =
-            _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), initialAmount);
+            _makeFungibleTransfer(ABudget.AssetType.ERC20, address(mockERC20), address(this), initialAmount);
 
         // Set up the mock to manipulate the balance after transfer
         vm.mockCall(
@@ -190,7 +190,7 @@ contract VestingBudgetTest is Test {
         );
 
         // Expect revert due to InvalidAllocation
-        vm.expectRevert(abi.encodeWithSelector(Budget.InvalidAllocation.selector, address(mockERC20), initialAmount));
+        vm.expectRevert(abi.encodeWithSelector(ABudget.InvalidAllocation.selector, address(mockERC20), initialAmount));
         vestingBudget.allocate(allocateData);
 
         vm.clearMockedCalls();
@@ -210,11 +210,11 @@ contract VestingBudgetTest is Test {
 
     function testAllocate_UnsupportedAssetType() public {
         bytes memory erc1155Data = abi.encode(
-            Budget.Transfer({
-                assetType: Budget.AssetType.ERC1155,
+            ABudget.Transfer({
+                assetType: ABudget.AssetType.ERC1155,
                 asset: address(mockERC1155),
                 target: address(this),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
+                data: abi.encode(ABudget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
             })
         );
 
@@ -332,11 +332,11 @@ contract VestingBudgetTest is Test {
 
     function testClawback_UnsupportedAssetType() public {
         bytes memory erc1155Data = abi.encode(
-            Budget.Transfer({
-                assetType: Budget.AssetType.ERC1155,
+            ABudget.Transfer({
+                assetType: ABudget.AssetType.ERC1155,
                 asset: address(mockERC1155),
                 target: address(this),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
+                data: abi.encode(ABudget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
             })
         );
 
@@ -497,11 +497,11 @@ contract VestingBudgetTest is Test {
 
     function testDisburse_UnsupportedAssetType() public {
         bytes memory erc1155Data = abi.encode(
-            Budget.Transfer({
-                assetType: Budget.AssetType.ERC1155,
+            ABudget.Transfer({
+                assetType: ABudget.AssetType.ERC1155,
                 asset: address(mockERC1155),
                 target: address(this),
-                data: abi.encode(Budget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
+                data: abi.encode(ABudget.ERC1155Payload({tokenId: 1, amount: 1, data: ""}))
             })
         );
 

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -736,11 +736,7 @@ contract VestingBudgetTest is Test {
         return abi.encode(transfer);
     }
 
-    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
-        external
-        pure
-        returns (bytes4)
-    {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
         return IERC1155Receiver.onERC1155Received.selector;
     }
 }

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -496,6 +496,23 @@ contract VestingBudgetTest is Test {
         vestingBudget.disburseBatch(requests);
     }
 
+    function testDisburse_UnsupportedAssetType() public {
+        bytes memory erc1155Data = abi.encode(
+            Budget.Transfer({
+                assetType: Budget.AssetType.ERC1155,
+                asset: address(mockERC1155),
+                target: address(this),
+                data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 100, data: ""}))
+            })
+        );
+
+        // Try to disburse ERC1155 tokens
+        bool result = vestingBudget.disburse(erc1155Data);
+
+        // Assert that disburse fails for unsupported asset type
+        assertFalse(result, "Disburse should fail for unsupported asset type (ERC1155)");
+    }
+
     /////////////////////////
     // VestingBudget.total //
     /////////////////////////

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -203,10 +203,10 @@ contract VestingBudgetTest is Test {
     }
 
     ///////////////////////////
-    // VestingBudget.reclaim  //
+    // VestingBudget.clawback //
     ///////////////////////////
 
-    function testReclaim() public {
+    function testClawback() public {
         _allocate(address(mockERC20), 100 ether);
         _vestAll();
 
@@ -224,7 +224,7 @@ contract VestingBudgetTest is Test {
         assertEq(vestingBudget.available(address(mockERC20)), 1 ether);
     }
 
-    function testReclaim_NativeBalance() public {
+    function testClawback_NativeBalance() public {
         // Allocate 100 ETH to the budget
         _allocate(address(0), 100 ether);
         _vestAll();
@@ -237,7 +237,7 @@ contract VestingBudgetTest is Test {
         assertEq(vestingBudget.available(address(0)), 1 ether);
     }
 
-    function testReclaim_ZeroAmount() public {
+    function testClawback_ZeroAmount() public {
         _allocate(address(mockERC20), 100 ether);
         _vestAll();
 
@@ -249,7 +249,7 @@ contract VestingBudgetTest is Test {
         assertEq(vestingBudget.available(address(mockERC20)), 0 ether);
     }
 
-    function testReclaim_ZeroAddress() public {
+    function testClawback_ZeroAddress() public {
         _allocate(address(mockERC20), 100 ether);
         _vestAll();
 
@@ -264,7 +264,7 @@ contract VestingBudgetTest is Test {
         assertEq(vestingBudget.available(address(mockERC20)), 100 ether);
     }
 
-    function testReclaim_InsufficientFunds() public {
+    function testClawback_InsufficientFunds() public {
         _allocate(address(mockERC20), 100 ether);
         _vestAll();
 
@@ -278,7 +278,7 @@ contract VestingBudgetTest is Test {
         vestingBudget.clawback(data);
     }
 
-    function testReclaim_ImproperData() public {
+    function testClawback_ImproperData() public {
         bytes memory data;
 
         // Approve the budget to transfer tokens
@@ -295,7 +295,7 @@ contract VestingBudgetTest is Test {
         vestingBudget.clawback(data);
     }
 
-    function testReclaim_NotOwner() public {
+    function testClawback_NotOwner() public {
         _allocate(address(mockERC20), 100 ether);
 
         // Try to reclaim 100 tokens from the budget as a non-owner

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -209,6 +209,23 @@ contract VestingBudgetTest is Test {
         vestingBudget.allocate(data);
     }
 
+    function testAllocate_UnsupportedAssetType() public {
+        bytes memory erc1155Data = abi.encode(
+            Budget.Transfer({
+                assetType: Budget.AssetType.ERC1155,
+                asset: address(mockERC1155),
+                target: address(this),
+                data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 100, data: ""}))
+            })
+        );
+
+        // Try to allocate ERC1155 tokens to budget
+        bool result = vestingBudget.allocate(erc1155Data);
+
+        // Assert that allocation fails for unsupported asset type
+        assertFalse(result, "Allocation should fail for unsupported asset type (ERC1155)");
+    }
+
     ///////////////////////////
     // VestingBudget.clawback //
     ///////////////////////////

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -609,7 +609,7 @@ contract VestingBudgetTest is Test {
     function testEnd() public view {
         uint256 expectedEnd = vestingBudget.start() + vestingBudget.duration();
         uint256 actualEnd = vestingBudget.end();
-        
+
         assertEq(actualEnd, expectedEnd, "End time should equal start + duration");
     }
 

--- a/packages/evm/test/budgets/VestingBudget.t.sol
+++ b/packages/evm/test/budgets/VestingBudget.t.sol
@@ -331,6 +331,23 @@ contract VestingBudgetTest is Test {
         );
     }
 
+    function testClawback_UnsupportedAssetType() public {
+        bytes memory erc1155Data = abi.encode(
+            Budget.Transfer({
+                assetType: Budget.AssetType.ERC1155,
+                asset: address(mockERC1155),
+                target: address(this),
+                data: abi.encode(Budget.ERC1155Payload({tokenId: 42, amount: 100, data: ""}))
+            })
+        );
+
+        // Try to clawback ERC1155 tokens
+        bool result = vestingBudget.clawback(erc1155Data);
+
+        // Assert that clawback fails for unsupported asset type
+        assertFalse(result, "Clawback should fail for unsupported asset type (ERC1155)");
+    }
+
     ///////////////////////////
     // VestingBudget.disburse //
     ///////////////////////////


### PR DESCRIPTION
~~Up to 92%. Ran into the same issues with the ASimpleBudget.~~
Up to 98%. Only line not covered is `reconcile` function. I was able to test unsupported asset type on this one since ERC1155 is not supported in the vesting budget.


- Reconcile is tested, but not being detected in coverage
- ~~Not able to test unsupported asset type. (See https://github.com/rabbitholegg/boost-protocol/pull/70)~~

