### PR TITLE
[BOOST-4693] Event Action Beautification / Hardening

### DIFF
--- a/.changeset/hungry-beds-peel.md
+++ b/.changeset/hungry-beds-peel.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+event action hardening, alternate event action payload shape, action step deduping

--- a/packages/sdk/src/Actions/Action.ts
+++ b/packages/sdk/src/Actions/Action.ts
@@ -22,12 +22,12 @@ export type Action = EventAction; // | ContractAction | ERC721MintAction
 /**
  * A map of Action component interfaces to their constructors.
  *
- * @type {{ "0x6c3129aa": EventAction; }}
+ * @type {{ "0x7687b0ed": EventAction; }}
  */
 export const ActionByComponentInterface = {
   // ['0x6c3129aa']: ContractAction,
   // ['0x97e083eb']: ERC721MintAction,
-  ['0x6c3129aa']: EventAction,
+  ['0x7687b0ed']: EventAction,
 };
 
 /**

--- a/packages/sdk/src/Actions/Action.ts
+++ b/packages/sdk/src/Actions/Action.ts
@@ -22,12 +22,12 @@ export type Action = EventAction; // | ContractAction | ERC721MintAction
 /**
  * A map of Action component interfaces to their constructors.
  *
- * @type {{ "0x7687b0ed": EventAction; }}
+ * @type {{ "0x6c3129aa": EventAction; }}
  */
 export const ActionByComponentInterface = {
   // ['0x6c3129aa']: ContractAction,
   // ['0x97e083eb']: ERC721MintAction,
-  ['0x7687b0ed']: EventAction,
+  ['0x6c3129aa']: EventAction,
 };
 
 /**

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -12,6 +12,7 @@ import { getClient } from '@wagmi/core';
 import {
   ContractFunctionExecutionError,
   type Hex,
+  type Log,
   encodeAbiParameters,
   encodeFunctionData,
   isAddress,
@@ -52,7 +53,7 @@ function basicErc721TransferAction(
     actionClaimant: {
       signatureType: SignatureType.EVENT,
       signature: selectors['Transfer(address,address,uint256)'] as Hex,
-      fieldIndex: 0,
+      fieldIndex: 2,
       targetContract: erc721.assertValidAddress(),
     },
     actionSteps: [
@@ -64,8 +65,8 @@ function basicErc721TransferAction(
         actionParameter: {
           filterType: FilterType.EQUAL,
           fieldType: PrimitiveType.ADDRESS,
-          fieldIndex: 0,
-          filterData: defaultOptions.account.address,
+          fieldIndex: 2,
+          filterData: accounts.at(1)!.account,
         },
       },
     ],
@@ -98,16 +99,114 @@ describe.only('EventAction', () => {
     expect(isAddress(action.assertValidAddress())).toBe(true);
   });
 
-  test('can read action steps', async () => {
+  test('can get an action step', async () => {
     const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    console.log(action);
-    console.log(
-      await readAEventActionGetActionSteps(defaultOptions.config, {
-        address: action.assertValidAddress(),
-        args: [],
-      }),
-    );
-    // const step = await action.getActionStepsCount();
-    // console.log(step);
+    const step = await action.getActionStep(0);
+    if (!step) throw new Error('there should be an action step at this index');
+    step.targetContract = step.targetContract.toUpperCase() as Hex;
+    step.actionParameter.filterData =
+      step.actionParameter.filterData.toUpperCase() as Hex;
+    expect(step).toMatchObject({
+      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signatureType: SignatureType.EVENT,
+      actionType: 0,
+      targetContract: erc721.assertValidAddress().toUpperCase(),
+      actionParameter: {
+        filterType: FilterType.EQUAL,
+        fieldType: PrimitiveType.ADDRESS,
+        fieldIndex: 2,
+        filterData: accounts.at(1)!.account.toUpperCase(),
+      },
+    });
+  });
+
+  test('can get all action steps', async () => {
+    const action = await loadFixture(cloneEventAction(fixtures, erc721));
+    const steps = await action.getActionSteps();
+    expect(steps.length).toBe(1);
+    const step = steps.at(0)!;
+    step.targetContract = step.targetContract.toUpperCase() as Hex;
+    step.actionParameter.filterData =
+      step.actionParameter.filterData.toUpperCase() as Hex;
+    expect(step).toMatchObject({
+      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signatureType: SignatureType.EVENT,
+      actionType: 0,
+      targetContract: erc721.assertValidAddress().toUpperCase(),
+      actionParameter: {
+        filterType: FilterType.EQUAL,
+        fieldType: PrimitiveType.ADDRESS,
+        fieldIndex: 2,
+        filterData: accounts.at(1)!.account.toUpperCase(),
+      },
+    });
+  });
+
+  test('can get the total number of action steps', async () => {
+    const action = await loadFixture(cloneEventAction(fixtures, erc721));
+    const count = await action.getActionStepsCount();
+    expect(count).toBe(1);
+  });
+
+  test('can get the action claimant', async () => {
+    const action = await loadFixture(cloneEventAction(fixtures, erc721));
+    const claimant = await action.getActionClaimant();
+    claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
+    expect(claimant).toMatchObject({
+      signatureType: SignatureType.EVENT,
+      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      fieldIndex: 2,
+      targetContract: erc721.assertValidAddress().toUpperCase(),
+    });
+  });
+
+  test('can get the action claimant', async () => {
+    const action = await loadFixture(cloneEventAction(fixtures, erc721));
+    const claimant = await action.getActionClaimant();
+    claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
+    expect(claimant).toMatchObject({
+      signatureType: SignatureType.EVENT,
+      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      fieldIndex: 2,
+      targetContract: erc721.assertValidAddress().toUpperCase(),
+    });
+  });
+
+  test('with no logs, does not validate', async () => {
+    const action = await loadFixture(cloneEventAction(fixtures, erc721));
+    expect(await action.validateActionSteps()).toBe(false);
+  });
+
+  test('with a correct log, validates', async () => {
+    const action = await loadFixture(cloneEventAction(fixtures, erc721));
+    const recipient = accounts.at(1)!.account;
+    await erc721.approve(recipient, 1n);
+    await erc721.transferFrom(defaultOptions.account.address, recipient, 1n);
+    expect(await action.validateActionSteps()).toBe(true);
+  });
+
+  test('can supply your own logs to validate against', async () => {
+    const log = {
+      eventName: 'Transfer',
+      args: undefined,
+      address: erc721.assertValidAddress(),
+      blockHash:
+        '0xbf602f988260519805d032be46d6ff97fbefbee6924b21097074d6d0bc34eced',
+      blockNumber: 1203n,
+      data: '0x',
+      logIndex: 0,
+      removed: false,
+      topics: [
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+        '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+        '0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8',
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      ],
+      transactionHash:
+        '0xff0e6ab0c4961ec14b7b40afec83ed7d7a77582683512a262e641d21f82efea5',
+      transactionIndex: 0,
+    } as Log;
+    const action = await loadFixture(cloneEventAction(fixtures, erc721));
+    expect(await action.validateActionSteps({ logs: [log] })).toBe(true);
   });
 });

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1,3 +1,7 @@
+import {
+  readAActionGetComponentInterface,
+  readEventActionGetComponentInterface,
+} from '@boostxyz/evm';
 import { selectors } from '@boostxyz/signatures/events';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { type Hex, type Log, isAddress } from 'viem';
@@ -124,18 +128,6 @@ describe('EventAction', () => {
     const action = await loadFixture(cloneEventAction(fixtures, erc721));
     const count = await action.getActionStepsCount();
     expect(count).toBe(1);
-  });
-
-  test('can get the action claimant', async () => {
-    const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    const claimant = await action.getActionClaimant();
-    claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
-    expect(claimant).toMatchObject({
-      signatureType: SignatureType.EVENT,
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
-      fieldIndex: 2,
-      targetContract: erc721.assertValidAddress().toUpperCase(),
-    });
   });
 
   test('can get the action claimant', async () => {

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1,0 +1,113 @@
+import {
+  mockErc20Abi,
+  readAEventActionGetActionSteps,
+  readEventActionGetActionStepsCount,
+  readEventActionGetComponentInterface,
+  readMockErc20BalanceOf,
+  writeAEventActionPrepare,
+} from '@boostxyz/evm';
+import { selectors } from '@boostxyz/signatures/events';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { getClient } from '@wagmi/core';
+import {
+  ContractFunctionExecutionError,
+  type Hex,
+  encodeAbiParameters,
+  encodeFunctionData,
+  isAddress,
+  parseEther,
+  toFunctionSelector,
+  zeroAddress,
+} from 'viem';
+import { call } from 'viem/actions';
+import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import type { MockERC20 } from '../../test/MockERC20';
+import type { MockERC721 } from '../../test/MockERC721';
+import { accounts } from '../../test/accounts';
+import {
+  type Fixtures,
+  defaultOptions,
+  deployFixtures,
+  fundErc20,
+  fundErc721,
+} from '../../test/helpers';
+import {
+  type EventActionPayloadSimple,
+  FilterType,
+  PrimitiveType,
+  SignatureType,
+} from '../utils';
+import { EventAction } from './EventAction';
+
+let fixtures: Fixtures, erc721: MockERC721;
+
+beforeAll(async () => {
+  fixtures = await loadFixture(deployFixtures);
+});
+
+function basicErc721TransferAction(
+  erc721: MockERC721,
+): EventActionPayloadSimple {
+  return {
+    actionClaimant: {
+      signatureType: SignatureType.EVENT,
+      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      fieldIndex: 0,
+      targetContract: erc721.assertValidAddress(),
+    },
+    actionSteps: [
+      {
+        signature: selectors['Transfer(address,address,uint256)'] as Hex,
+        signatureType: SignatureType.EVENT,
+        actionType: 0,
+        targetContract: erc721.assertValidAddress(),
+        actionParameter: {
+          filterType: FilterType.EQUAL,
+          fieldType: PrimitiveType.ADDRESS,
+          fieldIndex: 0,
+          filterData: defaultOptions.account.address,
+        },
+      },
+    ],
+  };
+}
+
+function cloneEventAction(fixtures: Fixtures, erc721: MockERC721) {
+  return function cloneEventAction() {
+    return fixtures.registry.clone(
+      crypto.randomUUID(),
+      new fixtures.bases.EventAction(
+        defaultOptions,
+        basicErc721TransferAction(erc721),
+      ),
+    );
+  };
+}
+
+describe.only('EventAction', () => {
+  beforeEach(async () => {
+    erc721 = await loadFixture(fundErc721(defaultOptions));
+  });
+
+  test('can successfully be deployed', async () => {
+    const action = new EventAction(
+      defaultOptions,
+      basicErc721TransferAction(erc721),
+    );
+    await action.deploy();
+    expect(isAddress(action.assertValidAddress())).toBe(true);
+  });
+
+  test('can read action steps', async () => {
+    const action = await loadFixture(cloneEventAction(fixtures, erc721));
+    console.log(action);
+    console.log(
+      await readAEventActionGetActionSteps(defaultOptions.config, {
+        address: action.assertValidAddress(),
+        args: [],
+      }),
+    );
+    // const step = await action.getActionStepsCount();
+    // console.log(step);
+  });
+});

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1,35 +1,13 @@
-import {
-  mockErc20Abi,
-  readAEventActionGetActionSteps,
-  readEventActionGetActionStepsCount,
-  readEventActionGetComponentInterface,
-  readMockErc20BalanceOf,
-  writeAEventActionPrepare,
-} from '@boostxyz/evm';
 import { selectors } from '@boostxyz/signatures/events';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
-import { getClient } from '@wagmi/core';
-import {
-  ContractFunctionExecutionError,
-  type Hex,
-  type Log,
-  encodeAbiParameters,
-  encodeFunctionData,
-  isAddress,
-  parseEther,
-  toFunctionSelector,
-  zeroAddress,
-} from 'viem';
-import { call } from 'viem/actions';
+import { type Hex, type Log, isAddress } from 'viem';
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
-import type { MockERC20 } from '../../test/MockERC20';
 import type { MockERC721 } from '../../test/MockERC721';
 import { accounts } from '../../test/accounts';
 import {
   type Fixtures,
   defaultOptions,
   deployFixtures,
-  fundErc20,
   fundErc721,
 } from '../../test/helpers';
 import {
@@ -85,7 +63,7 @@ function cloneEventAction(fixtures: Fixtures, erc721: MockERC721) {
   };
 }
 
-describe.only('EventAction', () => {
+describe('EventAction', () => {
   beforeEach(async () => {
     erc721 = await loadFixture(fundErc721(defaultOptions));
   });

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -9,7 +9,15 @@ import {
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/actions/EventAction.sol/EventAction.json';
 import events from '@boostxyz/signatures/events';
-import type { Abi, AbiEvent, Address, ContractEventName, Hex, Log } from 'viem';
+import {
+  type Abi,
+  type AbiEvent,
+  type Address,
+  type ContractEventName,
+  type Hex,
+  type Log,
+  isAddressEqual,
+} from 'viem';
 import { getLogs } from 'viem/actions';
 import type {
   DeployableOptions,
@@ -36,6 +44,7 @@ import {
   type ReadParams,
   RegistryType,
   type WriteParams,
+  dedupeActionSteps,
   isEventActionPayloadSimple,
   prepareEventActionPayload,
 } from '../utils';
@@ -92,13 +101,8 @@ export class EventAction extends DeployableTarget<
     index: number,
     params?: ReadParams<typeof eventActionAbi, 'getActionStep'>,
   ) {
-    return readEventActionGetActionStep(this._config, {
-      address: this.assertValidAddress(),
-      ...this.optionallyAttachAccount(),
-      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
-      ...(params as any),
-      args: [BigInt(index)],
-    }) as Promise<ActionStep>;
+    const steps = await this.getActionSteps(params);
+    return steps.at(index);
   }
 
   /**
@@ -112,12 +116,13 @@ export class EventAction extends DeployableTarget<
   public async getActionSteps(
     params?: ReadParams<typeof eventActionAbi, 'getActionSteps'>,
   ) {
-    return readEventActionGetActionSteps(this._config, {
+    const steps = (await readEventActionGetActionSteps(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
-    }) as Promise<ActionStep[]>;
+    })) as ActionStep[];
+    return dedupeActionSteps(steps);
   }
 
   /**
@@ -131,12 +136,8 @@ export class EventAction extends DeployableTarget<
   public async getActionStepsCount(
     params?: ReadParams<typeof eventActionAbi, 'getActionStepsCount'>,
   ) {
-    return readEventActionGetActionStepsCount(this._config, {
-      address: this.assertValidAddress(),
-      ...this.optionallyAttachAccount(),
-      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
-      ...(params as any),
-    });
+    const steps = await this.getActionSteps(params);
+    return steps.length;
   }
 
   /**
@@ -198,21 +199,29 @@ export class EventAction extends DeployableTarget<
     return { hash, result };
   }
 
-  /** Validates all action events
+  /**
+   * Retrieves action steps, and uses them to validate against, and optionally fetch logs that match the step's signature.
+   * If logs are provided in the optional `params` argument, then those logs will be used instead of fetched with the configured client.
+   *
    * @public
    * @async
+   * @param {?ReadParams<typeof eventActionAbi, 'getActionSteps'> &
+   *       GetLogsParams<Abi, ContractEventName<Abi>> & {
+   *         knownEvents?: Record<Hex, AbiEvent>;
+   *         logs?: Log[];
+   *       }} [params]
    * @returns {Promise<boolean>}
-   * @param {?ReadParams<typeof eventActionAbi, 'getActionSteps'>} [params]
    */
   public async validateActionSteps(
     params?: ReadParams<typeof eventActionAbi, 'getActionSteps'> &
       GetLogsParams<Abi, ContractEventName<Abi>> & {
         knownEvents?: Record<Hex, AbiEvent>;
+        logs?: Log[];
       },
   ) {
     const actionSteps = await this.getActionSteps(params);
     for (const actionStep of actionSteps) {
-      if (!this.isActionStepValid(actionStep, params)) {
+      if (!(await this.isActionStepValid(actionStep, params))) {
         return false;
       }
     }
@@ -220,16 +229,23 @@ export class EventAction extends DeployableTarget<
   }
 
   /**
-   * Validates a single action event
+   * Validates a single action step with a given criteria against logs.
+   * If logs are provided in the optional `params` argument, then those logs will be used instead of fetched with the configured client.
+   *
    * @public
    * @async
    * @param {ActionStep} actionStep
-   * @returns {boolean}
+   * @param {?GetLogsParams<Abi, ContractEventName<Abi>> & {
+   *       knownEvents?: Record<Hex, AbiEvent>;
+   *       logs?: Log[];
+   *     }} [params]
+   * @returns {Promise<boolean>}
    */
   public async isActionStepValid(
     actionStep: ActionStep,
     params?: GetLogsParams<Abi, ContractEventName<Abi>> & {
       knownEvents?: Record<Hex, AbiEvent>;
+      logs?: Log[];
     },
   ) {
     const criteria = actionStep.actionParameter;
@@ -246,15 +262,15 @@ export class EventAction extends DeployableTarget<
     }
     const targetContract = actionStep.targetContract;
     // Get all logs matching the event signature from the target contract
-    const logs = await getLogs(
-      this._config.getClient({ chainId: params?.chainId }),
-      {
+    const logs =
+      params?.logs ||
+      (await getLogs(this._config.getClient({ chainId: params?.chainId }), {
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
         ...(params as any),
         address: targetContract,
         event,
-      },
-    );
+      }));
+    if (!logs.length) return false;
     for (let log of logs) {
       if (!this.validateLogAgainstCriteria(criteria, log)) {
         return false;
@@ -264,11 +280,11 @@ export class EventAction extends DeployableTarget<
   }
 
   /**
-   * Validates a Viem event log against a given criteria.
+   * Validates a {@link Log} against a given criteria.
    *
    * @param {Criteria} criteria - The criteria to validate against.
-   * @param {any[]} log - The Viem event log array.
-   * @returns {boolean} - Returns true if the log passes the criteria, false otherwise.
+   * @param {Log} log - The Viem event log.
+   * @returns {Promise<boolean>} - Returns true if the log passes the criteria, false otherwise.
    */
   public async validateLogAgainstCriteria(criteria: Criteria, log: Log) {
     const fieldValue = log.topics.at(criteria.fieldIndex);
@@ -278,6 +294,12 @@ export class EventAction extends DeployableTarget<
     // Type narrow based on criteria.filterType
     switch (criteria.filterType) {
       case FilterType.EQUAL:
+        if (criteria.fieldType === PrimitiveType.ADDRESS) {
+          return isAddressEqual(
+            criteria.filterData,
+            `0x${fieldValue.slice(-40)}`,
+          );
+        }
         return fieldValue === criteria.filterData;
 
       case FilterType.NOT_EQUAL:

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -397,7 +397,7 @@ export interface ActionStep {
    */
   targetContract: Address;
   /**
-   * The criteria used for this action event.
+   * The criteria used for this action step.
    *
    * @type {Criteria}
    */
@@ -405,13 +405,53 @@ export interface ActionStep {
 }
 
 /**
+ * You can either supply a simplified version of the payload, or one that explicitly declares action steps.
+ *
+ * @export
+ * @typedef {EventActionPayload}
+ */
+export type EventActionPayload =
+  | EventActionPayloadSimple
+  | EventActionPayloadRaw;
+
+export interface EventActionPayloadSimple {
+  /**
+   *  The payload describing how claimants are identified
+   *
+   * @type {ActionClaimant}
+   */
+  actionClaimant: ActionClaimant;
+
+  /**
+   * Up to 4 action steps.
+   * If you supply less than 4, then the last step will be reused to satisfy the EventAction.InitPayload
+   * Any more than 4 will throw an error.
+   *
+   * @type {ActionStep[]}
+   */
+  actionSteps: ActionStep[];
+}
+
+/**
+ * Typeguard to determine if a user is supplying a simple or raw EventActionPayload
+ *
+ * @param {*} opts
+ * @returns {opts is EventActionPayloadSimple}
+ */
+export function isEventActionPayloadSimple(
+  opts: EventActionPayload,
+): opts is EventActionPayloadSimple {
+  return Array.isArray((opts as EventActionPayloadSimple).actionSteps);
+}
+
+/**
  * Object representation of an `InitPayload` struct used to initialize event actions.
  *
  * @export
- * @interface EventActionPayload
- * @typedef {EventActionPayload}
+ * @interface EventActionPayloadRaw
+ * @typedef {EventActionPayloadRaw}
  */
-export interface EventActionPayload {
+export interface EventActionPayloadRaw {
   /**
    *  The payload describing how claimants are identified
    *
@@ -419,25 +459,25 @@ export interface EventActionPayload {
    */
   actionClaimant: ActionClaimant;
   /**
-   * The first action event.
+   * The first action step.
    *
    * @type {ActionStep}
    */
   actionStepOne: ActionStep;
   /**
-   * The second action event.
+   * The second action step.
    *
    * @type {ActionStep}
    */
   actionStepTwo: ActionStep;
   /**
-   * The third action event.
+   * The third action step.
    *
    * @type {ActionStep}
    */
   actionStepThree: ActionStep;
   /**
-   * The fourth action event.
+   * The fourth action step.
    *
    * @type {ActionStep}
    */
@@ -448,10 +488,10 @@ export interface EventActionPayload {
  * Function to properly encode an event action payload.
  *
  * @param {InitPayload} param0
- * @param {ActionStep} param0.actionStepOne - The first action event to initialize.
- * @param {ActionStep} param0.actionStepTwo - The second action event to initialize.
- * @param {ActionStep} param0.actionStepThree - The third action event to initialize.
- * @param {ActionStep} param0.actionStepFour - The fourth action event to initialize.
+ * @param {ActionStep} param0.actionStepOne - The first action step to initialize.
+ * @param {ActionStep} param0.actionStepTwo - The second action step to initialize.
+ * @param {ActionStep} param0.actionStepThree - The third action step to initialize.
+ * @param {ActionStep} param0.actionStepFour - The fourth action step to initialize.
  * @returns {Hex}
  */
 export const prepareEventActionPayload = ({
@@ -460,7 +500,7 @@ export const prepareEventActionPayload = ({
   actionStepTwo,
   actionStepThree,
   actionStepFour,
-}: EventActionPayload) => {
+}: EventActionPayloadRaw) => {
   return encodeAbiParameters(
     [
       {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -2233,3 +2233,15 @@ export function prepareERC721MintActionValidate(
     [holder, toHex(payload)],
   );
 }
+
+export function dedupeActionSteps(_steps: ActionStep[]): ActionStep[] {
+  const steps: ActionStep[] = [],
+    signatures: Record<string, boolean> = {};
+  for (let step of _steps) {
+    const signature = JSON.stringify(step);
+    if (signatures[signature]) continue;
+    steps.push(step);
+    signatures[signature] = true;
+  }
+  return steps;
+}

--- a/packages/sdk/test/MockERC721.ts
+++ b/packages/sdk/test/MockERC721.ts
@@ -1,7 +1,11 @@
 import {
   mockErc721Abi,
+  simulateMockErc721Approve,
   simulateMockErc721Mint,
+  simulateMockErc721TransferFrom,
+  writeMockErc721Approve,
   writeMockErc721Mint,
+  writeMockErc721TransferFrom,
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/shared/Mocks.sol/MockERC721.json';
 import type { Address, Hex } from 'viem';
@@ -13,6 +17,59 @@ import {
 import type { WriteParams } from '../src/utils';
 
 export class MockERC721 extends Deployable<{}, typeof mockErc721Abi> {
+  public async approve(
+    address: Address,
+    amount: bigint,
+    params?: WriteParams<typeof mockErc721Abi, 'approve'>,
+  ) {
+    return this.awaitResult(this.approveRaw(address, amount, params));
+  }
+
+  public async approveRaw(
+    address: Address,
+    amount: bigint,
+    params?: WriteParams<typeof mockErc721Abi, 'mint'>,
+  ) {
+    const { request, result } = await simulateMockErc721Approve(this._config, {
+      address: this.assertValidAddress(),
+      args: [address, amount],
+      ...this.optionallyAttachAccount(),
+      // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+      ...(params as any),
+    });
+    const hash = await writeMockErc721Approve(this._config, request);
+    return { hash, result };
+  }
+
+  public async transferFrom(
+    from: Address,
+    to: Address,
+    id: bigint,
+    params?: WriteParams<typeof mockErc721Abi, 'transferFrom'>,
+  ) {
+    return this.awaitResult(this.transferFromRaw(from, to, id, params));
+  }
+
+  public async transferFromRaw(
+    from: Address,
+    to: Address,
+    id: bigint,
+    params?: WriteParams<typeof mockErc721Abi, 'transferFrom'>,
+  ) {
+    const { request, result } = await simulateMockErc721TransferFrom(
+      this._config,
+      {
+        address: this.assertValidAddress(),
+        args: [from, to, id],
+        ...this.optionallyAttachAccount(),
+        // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
+        ...(params as any),
+      },
+    );
+    const hash = await writeMockErc721TransferFrom(this._config, request);
+    return { hash, result };
+  }
+
   public async mint(
     address: Address,
     params?: WriteParams<typeof mockErc721Abi, 'mint'>,

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -7,8 +7,8 @@ import {
   writePointsInitialize,
 } from '@boostxyz/evm';
 import ContractActionArtifact from '@boostxyz/evm/artifacts/contracts/actions/ContractAction.sol/ContractAction.json';
-import EventActionArtifact from '@boostxyz/evm/artifacts/contracts/actions/ContractAction.sol/ContractAction.json';
 import ERC721MintActionArtifact from '@boostxyz/evm/artifacts/contracts/actions/ERC721MintAction.sol/ERC721MintAction.json';
+import EventActionArtifact from '@boostxyz/evm/artifacts/contracts/actions/EventAction.sol/EventAction.json';
 import SimpleAllowListArtifact from '@boostxyz/evm/artifacts/contracts/allowlists/SimpleAllowList.sol/SimpleAllowList.json';
 import SimpleDenyListArtifact from '@boostxyz/evm/artifacts/contracts/allowlists/SimpleDenyList.sol/SimpleDenyList.json';
 import ManagedBudgetArtifact from '@boostxyz/evm/artifacts/contracts/budgets/ManagedBudget.sol/ManagedBudget.json';

--- a/packages/sdk/test/viem.ts
+++ b/packages/sdk/test/viem.ts
@@ -21,7 +21,7 @@ export const testAccount = privateKeyToAccount(key);
 
 export const makeTestClient = () =>
   createTestClient({
-    transport: http(undefined, { retryCount: 0 }),
+    transport: http('http://127.0.0.1:8545', { retryCount: 0 }),
     chain: hardhat,
     mode: 'hardhat',
     account: testAccount,
@@ -34,6 +34,7 @@ export type TestClient = ReturnType<typeof makeTestClient>;
 
 export function setupConfig(walletClient = makeTestClient()) {
   return createConfig({
+    ssr: true,
     chains: [hardhat],
     client: () => walletClient,
   });


### PR DESCRIPTION
- offer alternate `EventActionPayloadSimple` where you can pass `actionSteps: ActionStep[]` instead of `{ actionStepOne: ActionStep, ...etc }`
- for all read ops, `getActionStep`, `getActionSteps`, etc. dedupe reused action steps, so while there are technically always 4 on the contract, the sdk will know which ones are unique.
- basic integration tests, can reference for example development
- typed errors
- fix validation for address equality