### PR TITLE
[BOOST-4692] Support chainId in EventAction

### DIFF
--- a/packages/evm/contracts/actions/AEventAction.sol
+++ b/packages/evm/contracts/actions/AEventAction.sol
@@ -46,6 +46,7 @@ abstract contract AEventAction is AAction {
         SignatureType signatureType;
         uint8 actionType;
         address targetContract;
+        uint256 chainid;
         Criteria actionParameter;
     }
 
@@ -59,11 +60,13 @@ abstract contract AEventAction is AAction {
     /// @param signature The 4 byte signature of the event or function
     /// @param fieldIndex The index corresponding to claimant.
     /// @param targetContract The address of the target contract
+    /// @param chainId The id of the evm chain the Event was emitted from
     struct ActionClaimant {
         SignatureType signatureType;
         bytes32 signature;
         uint8 fieldIndex;
         address targetContract;
+        uint256 chainid;
     }
 
     function getActionStepsCount() public view virtual returns (uint256);

--- a/packages/evm/contracts/actions/AEventAction.sol
+++ b/packages/evm/contracts/actions/AEventAction.sol
@@ -42,7 +42,7 @@ abstract contract AEventAction is AAction {
     }
 
     struct ActionStep {
-        bytes4 signature;
+        bytes32 signature;
         SignatureType signatureType;
         uint8 actionType;
         address targetContract;
@@ -61,7 +61,7 @@ abstract contract AEventAction is AAction {
     /// @param targetContract The address of the target contract
     struct ActionClaimant {
         SignatureType signatureType;
-        bytes4 signature;
+        bytes32 signature;
         uint8 fieldIndex;
         address targetContract;
     }

--- a/packages/evm/test/actions/EventAction.t.sol
+++ b/packages/evm/test/actions/EventAction.t.sol
@@ -28,7 +28,8 @@ contract EventActionTest is Test {
             signatureType: AEventAction.SignatureType.EVENT,
             signature: bytes4(keccak256("Transfer(address,address,uint256)")),
             fieldIndex: 0,
-            targetContract: address(mockAsset)
+            targetContract: address(mockAsset),
+            chainid: 1
         });
 
         criteria = AEventAction.Criteria({
@@ -43,6 +44,7 @@ contract EventActionTest is Test {
             signatureType: AEventAction.SignatureType.EVENT,
             actionType: 0,
             targetContract: address(mockAsset),
+            chainid: 1,
             actionParameter: criteria
         });
 

--- a/packages/sdk/src/Actions/Action.test.ts
+++ b/packages/sdk/src/Actions/Action.test.ts
@@ -25,6 +25,7 @@ export function basicErc721TransferAction(
 ): EventActionPayloadSimple {
   return {
     actionClaimant: {
+      chainid: 31337,
       signatureType: SignatureType.EVENT,
       signature: selectors['Transfer(address,address,uint256)'] as Hex,
       fieldIndex: 2,
@@ -32,6 +33,7 @@ export function basicErc721TransferAction(
     },
     actionSteps: [
       {
+        chainid: 31337,
         signature: selectors['Transfer(address,address,uint256)'] as Hex,
         signatureType: SignatureType.EVENT,
         actionType: 0,

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -2,7 +2,7 @@ import {
   readAActionGetComponentInterface,
   readEventActionGetComponentInterface,
 } from '@boostxyz/evm';
-import { selectors } from '@boostxyz/signatures/events';
+import { selectors as eventSelectors } from '@boostxyz/signatures/events';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { type Hex, type Log, isAddress } from 'viem';
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
@@ -34,13 +34,13 @@ function basicErc721TransferAction(
   return {
     actionClaimant: {
       signatureType: SignatureType.EVENT,
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
       fieldIndex: 2,
       targetContract: erc721.assertValidAddress(),
     },
     actionSteps: [
       {
-        signature: selectors['Transfer(address,address,uint256)'] as Hex,
+        signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
         signatureType: SignatureType.EVENT,
         actionType: 0,
         targetContract: erc721.assertValidAddress(),
@@ -54,6 +54,35 @@ function basicErc721TransferAction(
     ],
   };
 }
+
+/*
+function basicErc721MintFuncAction(
+  erc721: MockERC721,
+): EventActionPayloadSimple {
+  return {
+    actionClaimant: {
+      signatureType: SignatureType.FUNC,
+      signature: funcSelectors['mint(address)'] as Hex,
+      fieldIndex: 0,
+      targetContract: erc721.assertValidAddress(),
+    },
+    actionSteps: [
+      {
+        signature: funcSelectors['mint(address)'] as Hex,
+        signatureType: SignatureType.FUNC,
+        actionType: 0,
+        targetContract: erc721.assertValidAddress(),
+        actionParameter: {
+          filterType: FilterType.EQUAL,
+          fieldType: PrimitiveType.ADDRESS,
+          fieldIndex: 2,
+          filterData: accounts.at(1)!.account,
+        },
+      },
+    ],
+  };
+}
+*/
 
 function cloneEventAction(fixtures: Fixtures, erc721: MockERC721) {
   return function cloneEventAction() {
@@ -89,7 +118,7 @@ describe('EventAction', () => {
     step.actionParameter.filterData =
       step.actionParameter.filterData.toUpperCase() as Hex;
     expect(step).toMatchObject({
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
       signatureType: SignatureType.EVENT,
       actionType: 0,
       targetContract: erc721.assertValidAddress().toUpperCase(),
@@ -111,7 +140,7 @@ describe('EventAction', () => {
     step.actionParameter.filterData =
       step.actionParameter.filterData.toUpperCase() as Hex;
     expect(step).toMatchObject({
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
       signatureType: SignatureType.EVENT,
       actionType: 0,
       targetContract: erc721.assertValidAddress().toUpperCase(),
@@ -136,7 +165,7 @@ describe('EventAction', () => {
     claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
     expect(claimant).toMatchObject({
       signatureType: SignatureType.EVENT,
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
       fieldIndex: 2,
       targetContract: erc721.assertValidAddress().toUpperCase(),
     });

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -37,6 +37,7 @@ function basicErc721TransferAction(
       signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
       fieldIndex: 2,
       targetContract: erc721.assertValidAddress(),
+      chainid: defaultOptions.config.chains[0].id,
     },
     actionSteps: [
       {
@@ -44,6 +45,7 @@ function basicErc721TransferAction(
         signatureType: SignatureType.EVENT,
         actionType: 0,
         targetContract: erc721.assertValidAddress(),
+        chainid: defaultOptions.config.chains[0].id,
         actionParameter: {
           filterType: FilterType.EQUAL,
           fieldType: PrimitiveType.ADDRESS,

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -31,7 +31,6 @@ import {
   UnrecognizedFilterTypeError,
 } from '../errors';
 import {
-  type ActionClaimant,
   type ActionStep,
   type Criteria,
   type EventActionPayload,
@@ -39,10 +38,13 @@ import {
   FilterType,
   type GetLogsParams,
   PrimitiveType,
+  type RawActionClaimant,
+  type RawActionStep,
   type ReadParams,
   RegistryType,
   type WriteParams,
   dedupeActionSteps,
+  fromRawActionStep,
   isEventActionPayloadSimple,
   prepareEventActionPayload,
 } from '../utils';
@@ -119,8 +121,8 @@ export class EventAction extends DeployableTarget<
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
-    })) as ActionStep[];
-    return dedupeActionSteps(steps);
+    })) as RawActionStep[];
+    return dedupeActionSteps(steps.map(fromRawActionStep));
   }
 
   /**
@@ -149,12 +151,13 @@ export class EventAction extends DeployableTarget<
   public async getActionClaimant(
     params?: ReadParams<typeof eventActionAbi, 'getActionClaimant'>,
   ) {
-    return readEventActionGetActionClaimant(this._config, {
+    const result = (await readEventActionGetActionClaimant(this._config, {
       address: this.assertValidAddress(),
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
       ...(params as any),
-    }) as Promise<ActionClaimant>;
+    })) as RawActionClaimant;
+    return fromRawActionStep(result);
   }
 
   /**

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -512,7 +512,7 @@ export const prepareEventActionPayload = ({
             name: 'actionClaimant',
             components: [
               { type: 'uint8', name: 'signatureType' },
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'fieldIndex' },
               { type: 'address', name: 'targetContract' },
             ],
@@ -521,7 +521,7 @@ export const prepareEventActionPayload = ({
             type: 'tuple',
             name: 'actionStepOne',
             components: [
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
@@ -541,7 +541,7 @@ export const prepareEventActionPayload = ({
             type: 'tuple',
             name: 'actionStepTwo',
             components: [
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
@@ -561,7 +561,7 @@ export const prepareEventActionPayload = ({
             type: 'tuple',
             name: 'actionStepThree',
             components: [
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
@@ -581,7 +581,7 @@ export const prepareEventActionPayload = ({
             type: 'tuple',
             name: 'actionStepFour',
             components: [
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -362,6 +362,11 @@ export interface ActionClaimant {
    * @type {Address}
    */
   targetContract: Address;
+  /**
+   * The chain id of the target contract.
+   * @type {number}
+   */
+  chainid: number;
 }
 
 /**
@@ -397,11 +402,39 @@ export interface ActionStep {
    */
   targetContract: Address;
   /**
+   * The chain id of the target contract.
+   * @type {number}
+   */
+  chainid: number;
+  /**
    * The criteria used for this action step.
    *
    * @type {Criteria}
    */
   actionParameter: Criteria;
+}
+type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+export type RawActionStep = Overwrite<ActionStep, { chainid: bigint }>;
+export type RawActionClaimant = Overwrite<ActionClaimant, { chainid: bigint }>;
+
+export function toRawActionStep<T extends ActionStep | ActionClaimant>(obj: T) {
+  return {
+    ...obj,
+    chainid: BigInt(obj.chainid),
+  };
+}
+
+export function fromRawActionStep<T extends RawActionStep | RawActionClaimant>(
+  obj: T,
+) {
+  if (obj.chainid > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error('Chain ID exceeds max safe integer');
+  }
+
+  return {
+    ...obj,
+    chainid: Number(obj.chainid),
+  };
 }
 
 /**
@@ -501,6 +534,8 @@ export const prepareEventActionPayload = ({
   actionStepThree,
   actionStepFour,
 }: EventActionPayloadRaw) => {
+  // note chainIds are technically uint256 but viem treats them (safely) as numbers,
+  // so we encode them as uint32 here to avoid downcast issues
   return encodeAbiParameters(
     [
       {
@@ -515,6 +550,7 @@ export const prepareEventActionPayload = ({
               { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'fieldIndex' },
               { type: 'address', name: 'targetContract' },
+              { type: 'uint256', name: 'chainid' },
             ],
           },
           {
@@ -525,6 +561,7 @@ export const prepareEventActionPayload = ({
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
+              { type: 'uint256', name: 'chainid' },
               {
                 type: 'tuple',
                 name: 'actionParameter',
@@ -545,6 +582,7 @@ export const prepareEventActionPayload = ({
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
+              { type: 'uint256', name: 'chainid' },
               {
                 type: 'tuple',
                 name: 'actionParameter',
@@ -565,6 +603,7 @@ export const prepareEventActionPayload = ({
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
+              { type: 'uint256', name: 'chainid' },
               {
                 type: 'tuple',
                 name: 'actionParameter',
@@ -585,6 +624,7 @@ export const prepareEventActionPayload = ({
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
+              { type: 'uint256', name: 'chainid' },
               {
                 type: 'tuple',
                 name: 'actionParameter',
@@ -602,11 +642,11 @@ export const prepareEventActionPayload = ({
     ],
     [
       {
-        actionClaimant,
-        actionStepOne,
-        actionStepTwo,
-        actionStepThree,
-        actionStepFour,
+        actionClaimant: toRawActionStep(actionClaimant),
+        actionStepOne: toRawActionStep(actionStepOne),
+        actionStepTwo: toRawActionStep(actionStepTwo),
+        actionStepThree: toRawActionStep(actionStepThree),
+        actionStepFour: toRawActionStep(actionStepFour),
       },
     ],
   );

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -640,7 +640,8 @@ export function makeMockEventActionPayload(
   erc20Address: Address,
 ) {
   const step: ActionStep = {
-    signature: '0xddf252ad',
+    signature:
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
     signatureType: SignatureType.EVENT,
     actionType: 0,
     targetContract: erc20Address,
@@ -655,7 +656,39 @@ export function makeMockEventActionPayload(
   return {
     actionClaimant: {
       signatureType: SignatureType.EVENT,
-      signature: '0xddf252ad',
+      signature:
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      fieldIndex: 0,
+      targetContract: erc20Address,
+    },
+    actionStepOne: step,
+    actionStepTwo: step,
+    actionStepThree: step,
+    actionStepFour: step,
+  } as EventActionPayload;
+}
+
+export function makeMockFunctionActionPayload(
+  coreAddress: Address,
+  erc20Address: Address,
+) {
+  const step: ActionStep = {
+    signature: '0x40c10f19',
+    signatureType: SignatureType.FUNC,
+    actionType: 0,
+    targetContract: erc20Address,
+    actionParameter: {
+      filterType: FilterType.EQUAL,
+      fieldType: PrimitiveType.ADDRESS,
+      fieldIndex: 0, // Assume the first field in the log is the 'from' address
+      filterData: coreAddress,
+    },
+  };
+
+  return {
+    actionClaimant: {
+      signatureType: SignatureType.FUNC,
+      signature: '0x40c10f19',
       fieldIndex: 0,
       targetContract: erc20Address,
     },

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -645,6 +645,7 @@ export function makeMockEventActionPayload(
     signatureType: SignatureType.EVENT,
     actionType: 0,
     targetContract: erc20Address,
+    chainid: 31337,
     actionParameter: {
       filterType: FilterType.EQUAL,
       fieldType: PrimitiveType.ADDRESS,
@@ -655,6 +656,7 @@ export function makeMockEventActionPayload(
 
   return {
     actionClaimant: {
+      chainid: 31337,
       signatureType: SignatureType.EVENT,
       signature:
         '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
@@ -674,6 +676,7 @@ export function makeMockFunctionActionPayload(
 ) {
   const step: ActionStep = {
     signature: '0x40c10f19',
+    chainid: 31337,
     signatureType: SignatureType.FUNC,
     actionType: 0,
     targetContract: erc20Address,
@@ -691,6 +694,7 @@ export function makeMockFunctionActionPayload(
       signature: '0x40c10f19',
       fieldIndex: 0,
       targetContract: erc20Address,
+      chainid: 31337,
     },
     actionStepOne: step,
     actionStepTwo: step,

--- a/packages/signatures/build.js
+++ b/packages/signatures/build.js
@@ -1,6 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { parseAbiItem, toFunctionSelector } from 'viem';
+import { parseAbiItem, toEventSelector, toFunctionSelector } from 'viem';
 import events from './manifests/events.json' with { type: 'json' };
 import functions from './manifests/functions.json' with { type: 'json' };
 
@@ -21,9 +21,20 @@ function addToIndex(type, signature, target) {
     ? signature.split(type).at(1).trim()
     : signature;
   const itemString = `${type} ${signatureWithoutType}`;
-  const selector = toFunctionSelector(signature);
+  const selector = generateSelector(type, signature);
   target.abi[selector] = parseAbiItem(itemString);
   target.selectors[signatureWithoutType] = selector;
+}
+
+function generateSelector(type, signature) {
+  switch (type) {
+    case 'event':
+      return toEventSelector(signature);
+    case 'function':
+      return toFunctionSelector(signature);
+    default:
+      throw new Error(`Invalid type: ${type}`);
+  }
 }
 
 for (let signature of events) {

--- a/packages/signatures/manifests/events.json
+++ b/packages/signatures/manifests/events.json
@@ -1,5 +1,7 @@
 [
   "// Begin common builtin event signatures",
   "Transfer(address,address,uint256)",
-  "Purchased(address,address,uint256,uint256,uint256)"
+  "Purchased(address,address,uint256,uint256,uint256)",
+  "// Test signatures",
+  "Test(string)"
 ]

--- a/packages/signatures/manifests/functions.json
+++ b/packages/signatures/manifests/functions.json
@@ -1,5 +1,7 @@
 [
   "// Begin common builtin function signatures",
   "mint(address to, uint256 amount)",
-  "mintPayable(address to, uint256 amount)"
+  "mintPayable(address to, uint256 amount)",
+  "// Test function signatures",
+  "mint(address)"
 ]


### PR DESCRIPTION
resolves BOOST-4706: Add chainId to event action parameters
resolves BOOST-4707: support chainid in EventAction

chainId is needed to disambiguate the location of the address
