### PR TITLE
fix(sdk): build, publish sourcemaps

### DIFF
--- a/.changeset/empty-feet-cheat.md
+++ b/.changeset/empty-feet-cheat.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+configure sdk to generate sourcemaps, include src in dep bundle so as not to break "sources" field

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-alpha.5",
   "license": "GPL-3.0-or-later",
   "type": "module",
-  "files": ["dist"],
+  "files": ["dist", "src"],
   "repository": "https://github.com/rabbitholegg/boost-protocol",
   "author": "Boost Team<boost-team@boost.xyz>",
   "access": "public",

--- a/packages/sdk/vite.config.js
+++ b/packages/sdk/vite.config.js
@@ -18,6 +18,7 @@ const moduleDirectories = Object.keys(packageJson.exports).reduce(
 /** @type {import('vite').UserConfig} */
 export default {
   build: {
+    sourcemap: true,
     rollupOptions: {
       external: [/^viem/, /^@wagmi(?!.*\/codegen)/, /^@boostxyz\/signatures/],
     },


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/rabbitholegg/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
configure sdk vite to generate sourcemaps
configure sdk/package.json to include `src` in package artifact so as to not break the "sources" field in es module sourcemaps

fix #91 

💔 Thank you!
yw