### PR TITLE
[BOOST-4745] fix: migrate EventAction signature to bytes32

### DIFF
--- a/packages/evm/contracts/actions/AEventAction.sol
+++ b/packages/evm/contracts/actions/AEventAction.sol
@@ -42,7 +42,7 @@ abstract contract AEventAction is AAction {
     }
 
     struct ActionStep {
-        bytes4 signature;
+        bytes32 signature;
         SignatureType signatureType;
         uint8 actionType;
         address targetContract;
@@ -61,7 +61,7 @@ abstract contract AEventAction is AAction {
     /// @param targetContract The address of the target contract
     struct ActionClaimant {
         SignatureType signatureType;
-        bytes4 signature;
+        bytes32 signature;
         uint8 fieldIndex;
         address targetContract;
     }

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -2,7 +2,7 @@ import {
   readAActionGetComponentInterface,
   readEventActionGetComponentInterface,
 } from '@boostxyz/evm';
-import { selectors } from '@boostxyz/signatures/events';
+import { selectors as eventSelectors } from '@boostxyz/signatures/events';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { type Hex, type Log, isAddress } from 'viem';
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
@@ -34,13 +34,13 @@ function basicErc721TransferAction(
   return {
     actionClaimant: {
       signatureType: SignatureType.EVENT,
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
       fieldIndex: 2,
       targetContract: erc721.assertValidAddress(),
     },
     actionSteps: [
       {
-        signature: selectors['Transfer(address,address,uint256)'] as Hex,
+        signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
         signatureType: SignatureType.EVENT,
         actionType: 0,
         targetContract: erc721.assertValidAddress(),
@@ -54,6 +54,35 @@ function basicErc721TransferAction(
     ],
   };
 }
+
+/*
+function basicErc721MintFuncAction(
+  erc721: MockERC721,
+): EventActionPayloadSimple {
+  return {
+    actionClaimant: {
+      signatureType: SignatureType.FUNC,
+      signature: funcSelectors['mint(address)'] as Hex,
+      fieldIndex: 0,
+      targetContract: erc721.assertValidAddress(),
+    },
+    actionSteps: [
+      {
+        signature: funcSelectors['mint(address)'] as Hex,
+        signatureType: SignatureType.FUNC,
+        actionType: 0,
+        targetContract: erc721.assertValidAddress(),
+        actionParameter: {
+          filterType: FilterType.EQUAL,
+          fieldType: PrimitiveType.ADDRESS,
+          fieldIndex: 2,
+          filterData: accounts.at(1)!.account,
+        },
+      },
+    ],
+  };
+}
+*/
 
 function cloneEventAction(fixtures: Fixtures, erc721: MockERC721) {
   return function cloneEventAction() {
@@ -89,7 +118,7 @@ describe('EventAction', () => {
     step.actionParameter.filterData =
       step.actionParameter.filterData.toUpperCase() as Hex;
     expect(step).toMatchObject({
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
       signatureType: SignatureType.EVENT,
       actionType: 0,
       targetContract: erc721.assertValidAddress().toUpperCase(),
@@ -111,7 +140,7 @@ describe('EventAction', () => {
     step.actionParameter.filterData =
       step.actionParameter.filterData.toUpperCase() as Hex;
     expect(step).toMatchObject({
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
       signatureType: SignatureType.EVENT,
       actionType: 0,
       targetContract: erc721.assertValidAddress().toUpperCase(),
@@ -136,7 +165,7 @@ describe('EventAction', () => {
     claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
     expect(claimant).toMatchObject({
       signatureType: SignatureType.EVENT,
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
+      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
       fieldIndex: 2,
       targetContract: erc721.assertValidAddress().toUpperCase(),
     });

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -512,7 +512,7 @@ export const prepareEventActionPayload = ({
             name: 'actionClaimant',
             components: [
               { type: 'uint8', name: 'signatureType' },
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'fieldIndex' },
               { type: 'address', name: 'targetContract' },
             ],
@@ -521,7 +521,7 @@ export const prepareEventActionPayload = ({
             type: 'tuple',
             name: 'actionStepOne',
             components: [
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
@@ -541,7 +541,7 @@ export const prepareEventActionPayload = ({
             type: 'tuple',
             name: 'actionStepTwo',
             components: [
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
@@ -561,7 +561,7 @@ export const prepareEventActionPayload = ({
             type: 'tuple',
             name: 'actionStepThree',
             components: [
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },
@@ -581,7 +581,7 @@ export const prepareEventActionPayload = ({
             type: 'tuple',
             name: 'actionStepFour',
             components: [
-              { type: 'bytes4', name: 'signature' },
+              { type: 'bytes32', name: 'signature' },
               { type: 'uint8', name: 'signatureType' },
               { type: 'uint8', name: 'actionType' },
               { type: 'address', name: 'targetContract' },

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -640,7 +640,8 @@ export function makeMockEventActionPayload(
   erc20Address: Address,
 ) {
   const step: ActionStep = {
-    signature: '0xddf252ad',
+    signature:
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
     signatureType: SignatureType.EVENT,
     actionType: 0,
     targetContract: erc20Address,
@@ -655,7 +656,39 @@ export function makeMockEventActionPayload(
   return {
     actionClaimant: {
       signatureType: SignatureType.EVENT,
-      signature: '0xddf252ad',
+      signature:
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      fieldIndex: 0,
+      targetContract: erc20Address,
+    },
+    actionStepOne: step,
+    actionStepTwo: step,
+    actionStepThree: step,
+    actionStepFour: step,
+  } as EventActionPayload;
+}
+
+export function makeMockFunctionActionPayload(
+  coreAddress: Address,
+  erc20Address: Address,
+) {
+  const step: ActionStep = {
+    signature: '0x40c10f19',
+    signatureType: SignatureType.FUNC,
+    actionType: 0,
+    targetContract: erc20Address,
+    actionParameter: {
+      filterType: FilterType.EQUAL,
+      fieldType: PrimitiveType.ADDRESS,
+      fieldIndex: 0, // Assume the first field in the log is the 'from' address
+      filterData: coreAddress,
+    },
+  };
+
+  return {
+    actionClaimant: {
+      signatureType: SignatureType.FUNC,
+      signature: '0x40c10f19',
       fieldIndex: 0,
       targetContract: erc20Address,
     },

--- a/packages/signatures/build.js
+++ b/packages/signatures/build.js
@@ -1,6 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { parseAbiItem, toFunctionSelector } from 'viem';
+import { parseAbiItem, toEventSelector, toFunctionSelector } from 'viem';
 import events from './manifests/events.json' with { type: 'json' };
 import functions from './manifests/functions.json' with { type: 'json' };
 
@@ -21,9 +21,20 @@ function addToIndex(type, signature, target) {
     ? signature.split(type).at(1).trim()
     : signature;
   const itemString = `${type} ${signatureWithoutType}`;
-  const selector = toFunctionSelector(signature);
+  const selector = generateSelector(type, signature);
   target.abi[selector] = parseAbiItem(itemString);
   target.selectors[signatureWithoutType] = selector;
+}
+
+function generateSelector(type, signature) {
+  switch (type) {
+    case 'event':
+      return toEventSelector(signature);
+    case 'function':
+      return toFunctionSelector(signature);
+    default:
+      throw new Error(`Invalid type: ${type}`);
+  }
 }
 
 for (let signature of events) {

--- a/packages/signatures/manifests/events.json
+++ b/packages/signatures/manifests/events.json
@@ -1,5 +1,7 @@
 [
   "// Begin common builtin event signatures",
   "Transfer(address,address,uint256)",
-  "Purchased(address,address,uint256,uint256,uint256)"
+  "Purchased(address,address,uint256,uint256,uint256)",
+  "// Test signatures",
+  "Test(string)"
 ]

--- a/packages/signatures/manifests/functions.json
+++ b/packages/signatures/manifests/functions.json
@@ -1,5 +1,7 @@
 [
   "// Begin common builtin function signatures",
   "mint(address to, uint256 amount)",
-  "mintPayable(address to, uint256 amount)"
+  "mintPayable(address to, uint256 amount)",
+  "// Test function signatures",
+  "mint(address)"
 ]


### PR DESCRIPTION
### Description

These changes don't explicitly test function signature EventActions because
they aren't handled in the sdk yet. However, I've scaffolded some artifacts
for testing when the time comes
