### PR TITLE
[ADHOC] fix(EventAction): await validation in log criteria check

### DIFF
--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -270,7 +270,7 @@ export class EventAction extends DeployableTarget<
       }));
     if (!logs.length) return false;
     for (let log of logs) {
-      if (!this.validateLogAgainstCriteria(criteria, log)) {
+      if (!(await this.validateLogAgainstCriteria(criteria, log))) {
         return false;
       }
     }


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/rabbitholegg/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
Fixes a bug in `isActionStepValid` where it would always return true due to an un-awaited promise being used in a boolean conditional.

💔 Thank you!
