### PR TITLE
[BOOST-4752] fix(sdk): split EventAction input params into two objects

### DIFF
--- a/.changeset/great-files-cheer.md
+++ b/.changeset/great-files-cheer.md
@@ -1,0 +1,6 @@
+---
+"@boostxyz/sdk": minor
+---
+
+split out eventABI getter parameters from the validation parameters for
+validateActionSteps calls

--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,10 @@
       "packages/evm/cache_forge",
       "dist",
       ".next",
-      ".turbo"
+      ".turbo",
+      "assets",
+      "coverage",
+      "**/*.test.ts"
     ]
   },
   "linter": {

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -256,7 +256,9 @@ describe('EventAction Event Selector', () => {
       transactionIndex: 0,
     } as Log;
     const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    expect(await action.validateActionSteps({ logs: [log] })).toBe(true);
+    expect(
+      await action.validateActionSteps({ logParams: { logs: [log] } }),
+    ).toBe(true);
   });
 });
 
@@ -411,7 +413,7 @@ describe('EventAction Func Selector', () => {
 
     expect(
       await action.validateActionSteps({
-        hash,
+        logParams: { hash },
       }),
     ).toBe(true);
   });

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -257,7 +257,7 @@ describe('EventAction Event Selector', () => {
     } as Log;
     const action = await loadFixture(cloneEventAction(fixtures, erc721));
     expect(
-      await action.validateActionSteps({ logParams: { logs: [log] } }),
+      await action.validateActionSteps({ txParams: { logs: [log] } }),
     ).toBe(true);
   });
 });
@@ -413,7 +413,7 @@ describe('EventAction Func Selector', () => {
 
     expect(
       await action.validateActionSteps({
-        logParams: { hash },
+        txParams: { hash },
       }),
     ).toBe(true);
   });

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -257,7 +257,7 @@ describe('EventAction Event Selector', () => {
     } as Log;
     const action = await loadFixture(cloneEventAction(fixtures, erc721));
     expect(
-      await action.validateActionSteps({ txParams: { logs: [log] } }),
+      await action.validateActionSteps({  logs: [log]  }),
     ).toBe(true);
   });
 });
@@ -413,7 +413,7 @@ describe('EventAction Func Selector', () => {
 
     expect(
       await action.validateActionSteps({
-        txParams: { hash },
+        hash ,
       }),
     ).toBe(true);
   });

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -329,13 +329,6 @@ type ReadEventActionParams<
 
 type TxParams = ValidateEventStepParams | ValidateFunctionStepParams;
 
-type ValidateInputParams<
-  fnName extends ContractFunctionName<typeof eventActionAbi, 'pure' | 'view'>,
-> = {
-  getterParams?: ReadEventActionParams<fnName>;
-  txParams?: TxParams;
-};
-
 /**
  * A generic event action
  *
@@ -490,15 +483,13 @@ export class EventAction extends DeployableTarget<
    *
    * @public
    * @async
-   * @param {?ValidateInputParams<'getActionSteps'>} [params]
+   * @param {?TxParams} [params]
    * @returns {Promise<boolean>}
    */
-  public async validateActionSteps(
-    params?: ValidateInputParams<'getActionSteps'>,
-  ) {
-    const actionSteps = await this.getActionSteps(params?.getterParams);
+  public async validateActionSteps(params?: TxParams) {
+    const actionSteps = await this.getActionSteps();
     for (const actionStep of actionSteps) {
-      if (!(await this.isActionStepValid(actionStep, params?.txParams))) {
+      if (!(await this.isActionStepValid(actionStep, params))) {
         return false;
       }
     }


### PR DESCRIPTION
This allows for cleaner separations of concerns by separating the pre-gathered log params out from the getter/setter params for smart contract functions. However, the shape is not determined based on class state (ie action type), so a user can still potentially input incorrect validation params and only receive an error at runtime
