### PR TITLE
[ADHOC] refactor(sdk,tests): refactor testing api to support same api as non-test usage

### DIFF
--- a/packages/sdk/src/Actions/Action.test.ts
+++ b/packages/sdk/src/Actions/Action.test.ts
@@ -52,10 +52,7 @@ export function cloneEventAction(fixtures: Fixtures, erc721: MockERC721) {
   return function cloneEventAction() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.EventAction(
-        defaultOptions,
-        basicErc721TransferAction(erc721),
-      ),
+      fixtures.core.EventAction(basicErc721TransferAction(erc721)),
     );
   };
 }

--- a/packages/sdk/src/Actions/ContractAction.test.ts
+++ b/packages/sdk/src/Actions/ContractAction.test.ts
@@ -38,7 +38,7 @@ function payableContractAction(fixtures: Fixtures, erc20: MockERC20) {
   return function payableContractAction() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.ContractAction(defaultOptions, {
+      fixtures.core.ContractAction({
         chainId: BigInt(31_337),
         target: erc20.assertValidAddress(),
         selector: mintPayableSelector,
@@ -52,7 +52,7 @@ function nonPayableAction(fixtures: Fixtures, erc20: MockERC20) {
   return function nonPayableAction() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.ContractAction(defaultOptions, {
+      fixtures.core.ContractAction({
         chainId: BigInt(31_337),
         target: erc20.assertValidAddress(),
         selector: mintSelector,
@@ -66,7 +66,7 @@ function otherAction(fixtures: Fixtures, erc20: MockERC20) {
   return function nonPayableAction() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.ContractAction(defaultOptions, {
+      fixtures.core.ContractAction({
         chainId: BigInt(31_337) + 1n,
         target: erc20.assertValidAddress(),
         selector: mintSelector,

--- a/packages/sdk/src/Actions/ERC721MintAction.test.ts
+++ b/packages/sdk/src/Actions/ERC721MintAction.test.ts
@@ -31,7 +31,7 @@ function nonPayableAction(fixtures: Fixtures, erc721: MockERC721) {
   return function nonPayableAction() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.ERC721MintAction(defaultOptions, {
+      fixtures.core.ERC721MintAction({
         chainId: BigInt(31_337),
         target: erc721.assertValidAddress(),
         selector: mintSelector,

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -85,10 +85,7 @@ function cloneEventAction(fixtures: Fixtures, erc721: MockERC721) {
   return function cloneEventAction() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.EventAction(
-        defaultOptions,
-        basicErc721TransferAction(erc721),
-      ),
+      fixtures.core.EventAction(basicErc721TransferAction(erc721)),
     );
   };
 }

--- a/packages/sdk/src/AllowLists/AllowList.test.ts
+++ b/packages/sdk/src/AllowLists/AllowList.test.ts
@@ -21,7 +21,7 @@ function freshAllowList(fixtures: Fixtures) {
   return function freshAllowList() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.SimpleAllowList(defaultOptions, {
+      fixtures.core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
@@ -33,7 +33,7 @@ function freshDenyList(fixtures: Fixtures) {
   return function freshDenyList() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.SimpleDenyList(defaultOptions, {
+      fixtures.core.SimpleDenyList({
         owner: defaultOptions.account.address,
         denied: [defaultOptions.account.address],
       }),

--- a/packages/sdk/src/AllowLists/SimpleAllowList.test.ts
+++ b/packages/sdk/src/AllowLists/SimpleAllowList.test.ts
@@ -18,7 +18,7 @@ function freshAllowList(fixtures: Fixtures) {
   return function freshAllowList() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.SimpleAllowList(defaultOptions, {
+      fixtures.core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),

--- a/packages/sdk/src/AllowLists/SimpleDenyList.test.ts
+++ b/packages/sdk/src/AllowLists/SimpleDenyList.test.ts
@@ -18,7 +18,7 @@ function freshDenyList(fixtures: Fixtures) {
   return function freshDenyList() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.SimpleDenyList(defaultOptions, {
+      fixtures.core.SimpleDenyList({
         owner: defaultOptions.account.address,
         denied: [defaultOptions.account.address],
       }),

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -480,7 +480,7 @@ describe('BoostCore', () => {
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
-    const { budget, erc20, points } = budgets;
+    const { budget, erc20, points, erc1155 } = budgets;
     const allowList = await registry.initialize(
       'SharedAllowList',
       core.SimpleAllowList({
@@ -495,13 +495,13 @@ describe('BoostCore', () => {
       limit: 10n,
       strategy: StrategyType.POOL,
     });
-    // const erc1155Incentive = core.ERC1155Incentive({
-    // 	asset: erc1155.assertValidAddress(),
-    // 	strategy: ERC1155StrategyType.POOL,
-    // 	limit: 1n,
-    // 	tokenId: 1n,
-    // 	extraData: "0x",
-    // });
+    const erc1155Incentive = core.ERC1155Incentive({
+      asset: erc1155.assertValidAddress(),
+      strategy: ERC1155StrategyType.POOL,
+      limit: 1n,
+      tokenId: 1n,
+      extraData: '0x',
+    });
     const cgdaIncentive = core.CGDAIncentive({
       asset: erc20.assertValidAddress(),
       initialReward: 1n,
@@ -537,7 +537,7 @@ describe('BoostCore', () => {
       }),
       allowList: core.SimpleAllowList(allowList.assertValidAddress()),
       incentives: [
-        // erc1155Incentive,
+        erc1155Incentive,
         erc20Incentive,
         cgdaIncentive,
         allowListIncentive,

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -28,39 +28,34 @@ describe('BoostCore', () => {
   });
 
   test('can get the total number of boosts', async () => {
-    const { core, bases } = fixtures;
+    const { core } = fixtures;
     const client = new BoostCore({
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
 
-    // to whom it may concern, this syntax is only used because we need to use test classes
-    // that are preconfigured with the dynamic base addresses generated at test time.
-    // normally you would use the follow api for brevity
-    // budget: client.SimpleBudget({} | '0xaddress')
     const { budget, erc20 } = budgets;
     await client.createBoost({
       protocolFee: 1n,
       referralFee: 2n,
       maxParticipants: 100n,
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,
@@ -72,39 +67,33 @@ describe('BoostCore', () => {
   });
 
   test('can successfully create a boost using all base contract implementations', async () => {
-    const { core, bases } = fixtures;
+    const { core } = fixtures;
     const client = new BoostCore({
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
-
-    // to whom it may concern, this syntax is only used because we need to use test classes
-    // that are preconfigured with the dynamic base addresses generated at test time.
-    // normally you would use the follow api for brevity
-    // budget: client.SimpleBudget({} | '0xaddress')
     const { budget, erc20 } = budgets;
     const boost = await client.createBoost({
       protocolFee: 1n,
       referralFee: 2n,
       maxParticipants: 100n,
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,
@@ -165,39 +154,33 @@ describe('BoostCore', () => {
   });
 
   test('can read the raw on chain representation of a boost', async () => {
-    const { core, bases } = fixtures;
+    const { core } = fixtures;
     const client = new BoostCore({
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
-
-    // to whom it may concern, this syntax is only used because we need to use test classes
-    // that are preconfigured with the dynamic base addresses generated at test time.
-    // normally you would use the follow api for brevity
-    // budget: client.SimpleBudget({} | '0xaddress')
     const { budget, erc20 } = budgets;
     const _boost = await client.createBoost({
       protocolFee: 1n,
       referralFee: 2n,
       maxParticipants: 100n,
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,
@@ -219,16 +202,11 @@ describe('BoostCore', () => {
   });
 
   test('can reuse an existing action', async () => {
-    const { core, bases } = fixtures;
+    const { core } = fixtures;
     const client = new BoostCore({
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
-
-    // to whom it may concern, this syntax is only used because we need to use test classes
-    // that are preconfigured with the dynamic base addresses generated at test time.
-    // normally you would use the follow api for brevity
-    // budget: client.SimpleBudget({} | '0xaddress')
     const { budget, erc20 } = budgets;
 
     // allocate more funds to the budget
@@ -242,23 +220,22 @@ describe('BoostCore', () => {
 
     const _boost = await client.createBoost({
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,
@@ -268,21 +245,17 @@ describe('BoostCore', () => {
     });
     const boost = await client.createBoost({
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
-        _boost.action.assertValidAddress(),
-        false,
-      ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      action: core.EventAction(_boost.action.assertValidAddress(), false),
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,
@@ -295,16 +268,11 @@ describe('BoostCore', () => {
   });
 
   test('can reuse an existing validator', async () => {
-    const { core, bases } = fixtures;
+    const { core } = fixtures;
     const client = new BoostCore({
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
-
-    // to whom it may concern, this syntax is only used because we need to use test classes
-    // that are preconfigured with the dynamic base addresses generated at test time.
-    // normally you would use the follow api for brevity
-    // budget: client.SimpleBudget({} | '0xaddress')
     const { budget, erc20 } = budgets;
 
     // allocate more erc20 funds to the budget from the owning accound
@@ -318,23 +286,22 @@ describe('BoostCore', () => {
 
     const _boost = await client.createBoost({
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,
@@ -344,24 +311,22 @@ describe('BoostCore', () => {
     });
     const boost = await client.createBoost({
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(
-        defaultOptions,
+      validator: core.SignerValidator(
         _boost.validator.assertValidAddress(),
         false,
       ),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,
@@ -374,16 +339,11 @@ describe('BoostCore', () => {
   });
 
   test('can reuse an existing allowlist', async () => {
-    const { core, bases } = fixtures;
+    const { core } = fixtures;
     const client = new BoostCore({
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
-
-    // to whom it may concern, this syntax is only used because we need to use test classes
-    // that are preconfigured with the dynamic base addresses generated at test time.
-    // normally you would use the follow api for brevity
-    // budget: client.SimpleBudget({} | '0xaddress')
     const { budget, erc20 } = budgets;
 
     // allocate more erc20 funds to the budget from the owning accound
@@ -397,23 +357,22 @@ describe('BoostCore', () => {
 
     const _boost = await client.createBoost({
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,
@@ -423,24 +382,22 @@ describe('BoostCore', () => {
     });
     const boost = await client.createBoost({
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(
-        defaultOptions,
+      allowList: core.SimpleAllowList(
         _boost.allowList.assertValidAddress(),
         false,
       ),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,
@@ -453,16 +410,11 @@ describe('BoostCore', () => {
   });
 
   test('cannot reuse an existing incentive', async () => {
-    const { core, bases } = fixtures;
+    const { core } = fixtures;
     const client = new BoostCore({
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
-
-    // to whom it may concern, this syntax is only used because we need to use test classes
-    // that are preconfigured with the dynamic base addresses generated at test time.
-    // normally you would use the follow api for brevity
-    // budget: client.SimpleBudget({} | '0xaddress')
     const { budget, erc20 } = budgets;
 
     // allocate more erc20 funds to the budget from the owning accound
@@ -474,7 +426,7 @@ describe('BoostCore', () => {
       target: defaultOptions.account.address,
     });
 
-    const incentive = new bases.ERC20Incentive(defaultOptions, {
+    const incentive = core.ERC20Incentive({
       asset: erc20.assertValidAddress(),
       reward: parseEther('1'),
       limit: 100n,
@@ -482,18 +434,17 @@ describe('BoostCore', () => {
     });
     const _boost = await client.createBoost({
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
@@ -502,18 +453,17 @@ describe('BoostCore', () => {
     try {
       await client.createBoost({
         budget: budget,
-        action: new bases.EventAction(
-          defaultOptions,
+        action: core.EventAction(
           makeMockEventActionPayload(
             core.assertValidAddress(),
             erc20.assertValidAddress(),
           ),
         ),
-        validator: new bases.SignerValidator(defaultOptions, {
+        validator: core.SignerValidator({
           signers: [defaultOptions.account.address],
           validatorCaller: defaultOptions.account.address,
         }),
-        allowList: new bases.SimpleAllowList(defaultOptions, {
+        allowList: core.SimpleAllowList({
           owner: defaultOptions.account.address,
           allowed: [defaultOptions.account.address],
         }),
@@ -525,50 +475,45 @@ describe('BoostCore', () => {
   });
 
   test('can offer multiple incentives', async () => {
-    const { registry, core, bases } = fixtures;
+    const { registry, core } = fixtures;
     const client = new BoostCore({
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
-
-    // to whom it may concern, this syntax is only used because we need to use test classes
-    // that are preconfigured with the dynamic base addresses generated at test time.
-    // normally you would use the follow api for brevity
-    // budget: client.SimpleBudget({} | '0xaddress')
-    const { budget, erc20, points, erc1155 } = budgets;
-    const allowList = await registry.clone(
+    const { budget, erc20, points } = budgets;
+    const allowList = await registry.initialize(
       'SharedAllowList',
-      new bases.SimpleAllowList(defaultOptions, {
+      core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
     );
 
-    const erc20Incentive = new bases.ERC20Incentive(defaultOptions, {
+    const erc20Incentive = core.ERC20Incentive({
       asset: erc20.assertValidAddress(),
       reward: 1n,
       limit: 10n,
       strategy: StrategyType.POOL,
     });
-    const erc1155Incentive = new bases.ERC1155Incentive(defaultOptions, {
-      asset: erc1155.assertValidAddress(),
-      strategy: ERC1155StrategyType.POOL,
-      limit: 1n,
-      tokenId: 1n,
-      extraData: '0x',
-    });
-    const cgdaIncentive = new bases.CGDAIncentive(defaultOptions, {
+    // const erc1155Incentive = core.ERC1155Incentive({
+    // 	asset: erc1155.assertValidAddress(),
+    // 	strategy: ERC1155StrategyType.POOL,
+    // 	limit: 1n,
+    // 	tokenId: 1n,
+    // 	extraData: "0x",
+    // });
+    const cgdaIncentive = core.CGDAIncentive({
       asset: erc20.assertValidAddress(),
       initialReward: 1n,
       totalBudget: 10n,
       rewardBoost: 1n,
       rewardDecay: 1n,
     });
-    const allowListIncentive = new bases.AllowListIncentive(defaultOptions, {
+    const allowListIncentive = core.AllowListIncentive({
       allowList: allowList.assertValidAddress(),
       limit: 5n,
     });
-    const pointsIncentive = new bases.PointsIncentive(defaultOptions, {
+    const pointsIncentive = core.PointsIncentive({
       venue: points.assertValidAddress(),
       selector: bytes4('issue(address,uint256)'),
       reward: 1n,
@@ -580,24 +525,19 @@ describe('BoostCore', () => {
       referralFee: 2n,
       maxParticipants: 100n,
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(
-        defaultOptions,
-        allowList.assertValidAddress(),
-        false,
-      ),
+      allowList: core.SimpleAllowList(allowList.assertValidAddress()),
       incentives: [
-        erc1155Incentive,
+        // erc1155Incentive,
         erc20Incentive,
         cgdaIncentive,
         allowListIncentive,
@@ -772,40 +712,34 @@ describe('BoostCore', () => {
   test('can subscribe to contract events', async () => {
     const subscription = vi.fn();
 
-    const { core, bases } = fixtures;
+    const { core } = fixtures;
     const client = new BoostCore({
       ...defaultOptions,
       address: core.assertValidAddress(),
     });
     client.subscribe(subscription, { pollingInterval: 100 });
-
-    // to whom it may concern, this syntax is only used because we need to use test classes
-    // that are preconfigured with the dynamic base addresses generated at test time.
-    // normally you would use the follow api for brevity
-    // budget: client.SimpleBudget({} | '0xaddress')
     const { budget, erc20 } = budgets;
     await client.createBoost({
       protocolFee: 1n,
       referralFee: 2n,
       maxParticipants: 100n,
       budget: budget,
-      action: new bases.EventAction(
-        defaultOptions,
+      action: core.EventAction(
         makeMockEventActionPayload(
           core.assertValidAddress(),
           erc20.assertValidAddress(),
         ),
       ),
-      validator: new bases.SignerValidator(defaultOptions, {
+      validator: core.SignerValidator({
         signers: [defaultOptions.account.address],
         validatorCaller: defaultOptions.account.address,
       }),
-      allowList: new bases.SimpleAllowList(defaultOptions, {
+      allowList: core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
       incentives: [
-        new bases.ERC20Incentive(defaultOptions, {
+        core.ERC20Incentive({
           asset: erc20.assertValidAddress(),
           reward: parseEther('1'),
           limit: 100n,

--- a/packages/sdk/src/Incentives/AllowListIncentive.test.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.test.ts
@@ -17,7 +17,7 @@ function freshAllowList(fixtures: Fixtures) {
   return function freshAllowList() {
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.SimpleAllowList(defaultOptions, {
+      fixtures.core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [],
       }),

--- a/packages/sdk/src/Incentives/CGDAIncentive.test.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.test.ts
@@ -41,7 +41,7 @@ describe('CGDAIncentive', () => {
     const referrer = accounts.at(1)!.account!;
     // biome-ignore lint/style/noNonNullAssertion: we know this is defined
     const trustedSigner = accounts.at(0)!;
-    const erc20Incentive = new fixtures.bases.CGDAIncentive(defaultOptions, {
+    const erc20Incentive = fixtures.core.CGDAIncentive({
       asset: budgets.erc20.assertValidAddress(),
       initialReward: 1n,
       totalBudget: 10n,
@@ -86,7 +86,7 @@ describe('CGDAIncentive', () => {
     const referrer = accounts.at(1)!.account!;
     // biome-ignore lint/style/noNonNullAssertion: we know this is defined
     const trustedSigner = accounts.at(0)!;
-    const erc20Incentive = new fixtures.bases.CGDAIncentive(defaultOptions, {
+    const erc20Incentive = fixtures.core.CGDAIncentive({
       asset: budgets.erc20.assertValidAddress(),
       initialReward: 1n,
       totalBudget: 10n,

--- a/packages/sdk/src/Incentives/ERC20Incentive.test.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.test.ts
@@ -42,7 +42,7 @@ describe('ERC20Incentive', () => {
     const referrer = accounts.at(1)!.account!,
       // biome-ignore lint/style/noNonNullAssertion: we know this is defined
       trustedSigner = accounts.at(0)!;
-    const erc20Incentive = new fixtures.bases.ERC20Incentive(defaultOptions, {
+    const erc20Incentive = fixtures.core.ERC20Incentive({
       asset: budgets.erc20.assertValidAddress(),
       strategy: StrategyType.POOL,
       reward: 1n,
@@ -85,7 +85,7 @@ describe('ERC20Incentive', () => {
     const referrer = accounts.at(1)!.account!;
     // biome-ignore lint/style/noNonNullAssertion: we know this is defined
     const trustedSigner = accounts.at(0)!;
-    const erc20Incentive = new fixtures.bases.ERC20Incentive(defaultOptions, {
+    const erc20Incentive = fixtures.core.ERC20Incentive({
       asset: budgets.erc20.assertValidAddress(),
       strategy: StrategyType.POOL,
       reward: 1n,

--- a/packages/sdk/src/Incentives/PointsIncentive.test.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.test.ts
@@ -41,7 +41,7 @@ describe('PointsIncentive', () => {
     const referrer = accounts.at(1)!.account!;
     // biome-ignore lint/style/noNonNullAssertion: we know this is defined
     const trustedSigner = accounts.at(0)!;
-    const pointsIncentive = new fixtures.bases.PointsIncentive(defaultOptions, {
+    const pointsIncentive = fixtures.core.PointsIncentive({
       venue: points.assertValidAddress(),
       selector: bytes4('issue(address,uint256)'),
       reward: 1n,
@@ -90,7 +90,7 @@ describe('PointsIncentive', () => {
     // biome-ignore lint/style/noNonNullAssertion: we know this is defined
     const trustedSigner = accounts.at(0)!;
 
-    const pointsIncentive = new fixtures.bases.PointsIncentive(defaultOptions, {
+    const pointsIncentive = fixtures.core.PointsIncentive({
       venue: points.assertValidAddress(),
       selector: bytes4('issue(address,uint256)'),
       reward,

--- a/packages/sdk/src/Validators/SignerValidator.test.ts
+++ b/packages/sdk/src/Validators/SignerValidator.test.ts
@@ -18,7 +18,7 @@ function freshValidator(fixtures: Fixtures) {
     const account = accounts.at(1)!.account;
     return fixtures.registry.clone(
       crypto.randomUUID(),
-      new fixtures.bases.SignerValidator(defaultOptions, {
+      fixtures.core.SignerValidator({
         signers: [defaultOptions.account.address, account],
         validatorCaller: testAccount.address,
       }),

--- a/packages/sdk/test/delegate-action.test.ts
+++ b/packages/sdk/test/delegate-action.test.ts
@@ -67,7 +67,7 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
     test('should create a boost for incentivizing delegation to a specific address', async () => {
       const { budget, erc20 } = budgets;
 
-      const { core, bases } = fixtures;
+      const { core } = fixtures;
 
       const client = new BoostCore({
         ...defaultOptions,
@@ -104,10 +104,7 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
         actionSteps: [eventActionStep],
       };
       // Initialize EventAction with the custom payload
-      const eventAction = new bases.EventAction(
-        defaultOptions,
-        eventActionPayload,
-      );
+      const eventAction = core.EventAction(eventActionPayload);
       // Create the boost using the custom EventAction
       await client.createBoost({
         protocolFee: 250n,
@@ -115,16 +112,16 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
         maxParticipants: 100n,
         budget: budget, // Use the ManagedBudget
         action: eventAction, // Pass the manually created EventAction
-        validator: new bases.SignerValidator(defaultOptions, {
+        validator: core.SignerValidator({
           signers: [owner, trustedSigner.account!], // Whichever account we're going to sign with needs to be a signer
           validatorCaller: fixtures.core.assertValidAddress(), // Only core should be calling into the validate otherwise it's possible to burn signatures
         }),
-        allowList: new bases.SimpleAllowList(defaultOptions, {
+        allowList: core.SimpleAllowList({
           owner: owner,
           allowed: [owner],
         }),
         incentives: [
-          new bases.ERC20Incentive(defaultOptions, {
+          core.ERC20Incentive({
             asset: erc20.assertValidAddress(),
             reward: parseEther('1'),
             limit: 100n,

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -387,7 +387,7 @@ export async function deployFixtures(
       );
     }
     SimpleBudget(options: DeployablePayloadOrAddress<SimpleBudgetPayload>) {
-      return new SimpleBudget(
+      return new bases.SimpleBudget(
         { config: this._config, account: this._account },
         options,
       );
@@ -401,7 +401,7 @@ export async function deployFixtures(
       );
     }
     VestingBudget(options: DeployablePayloadOrAddress<VestingBudgetPayload>) {
-      return new VestingBudget(
+      return new bases.VestingBudget(
         { config: this._config, account: this._account },
         options,
       );
@@ -425,7 +425,7 @@ export async function deployFixtures(
       );
     }
     ERC1155Incentive(options: ERC1155IncentivePayload) {
-      return new ERC1155Incentive(
+      return new bases.ERC1155Incentive(
         { config: this._config, account: this._account },
         options,
       );

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -27,32 +27,61 @@ import { type Address, type Hex, parseEther, zeroAddress } from 'viem';
 import {
   type ActionStep,
   AllowListIncentive,
+  type AllowListIncentivePayload,
   BoostCore,
   type Budget,
   CGDAIncentive,
+  type CGDAIncentivePayload,
   type CreateBoostPayload,
   ERC20Incentive,
+  type ERC20IncentivePayload,
   ERC20VariableIncentive,
   EventAction,
   type EventActionPayload,
   FilterType,
   ManagedBudget,
   PointsIncentive,
+  type PointsIncentivePayload,
   PrimitiveType,
   SignatureType,
   SignerValidator,
+  type SignerValidatorPayload,
   SimpleAllowList,
+  type SimpleAllowListPayload,
   SimpleDenyList,
+  type SimpleDenyListPayload,
 } from '../src';
-import { ContractAction } from '../src/Actions/ContractAction';
-import { ERC721MintAction } from '../src/Actions/ERC721MintAction';
+import {
+  ContractAction,
+  type ContractActionPayload,
+} from '../src/Actions/ContractAction';
+import {
+  ERC721MintAction,
+  type ERC721MintActionPayload,
+} from '../src/Actions/ERC721MintAction';
 import { BoostRegistry } from '../src/BoostRegistry';
-import { ManagedBudgetRoles } from '../src/Budgets/ManagedBudget';
-import { VestingBudget } from '../src/Budgets/VestingBudget';
-import { ERC1155Incentive } from '../src/Incentives/ERC1155Incentive';
+import {
+  type ManagedBudgetPayload,
+  ManagedBudgetRoles,
+} from '../src/Budgets/ManagedBudget';
+import {
+  VestingBudget,
+  type VestingBudgetPayload,
+} from '../src/Budgets/VestingBudget';
+import type { ERC20VariableIncentivePayload } from '../src/Incentives/ERC20VariableIncentive';
+import {
+  ERC1155Incentive,
+  type ERC1155IncentivePayload,
+} from '../src/Incentives/ERC1155Incentive';
 import { getDeployedContractAddress } from '../src/utils';
-import { SimpleBudget } from './../src/Budgets/SimpleBudget';
-import type { DeployableOptions } from './../src/Deployable/Deployable';
+import {
+  SimpleBudget,
+  type SimpleBudgetPayload,
+} from './../src/Budgets/SimpleBudget';
+import type {
+  DeployableOptions,
+  DeployablePayloadOrAddress,
+} from './../src/Deployable/Deployable';
 import { MockERC20 } from './MockERC20';
 import { MockERC721 } from './MockERC721';
 import { MockERC1155 } from './MockERC1155';
@@ -102,7 +131,7 @@ export async function freshBoost(
       ),
     validator:
       options.validator ||
-      new fixtures.bases.SignerValidator(defaultOptions, {
+      fixtures.core.SignerValidator({
         signers: [
           defaultOptions.account.address,
           accounts.at(0)?.account as Address,
@@ -111,7 +140,7 @@ export async function freshBoost(
       }),
     allowList:
       options.allowList ||
-      new fixtures.bases.SimpleAllowList(defaultOptions, {
+      fixtures.core.SimpleAllowList({
         owner: defaultOptions.account.address,
         allowed: [defaultOptions.account.address],
       }),
@@ -126,11 +155,6 @@ export async function deployFixtures(
   const registry = await new BoostRegistry({
     address: null,
     ...options,
-  }).deploy();
-  const core = await new BoostCore({
-    ...options,
-    registryAddress: registry.assertValidAddress(),
-    protocolFeeReceiver: account.address,
   }).deploy();
 
   const contractActionBase = await getDeployedContractAddress(
@@ -308,9 +332,138 @@ export async function deployFixtures(
   };
 
   for (const [name, deployable] of Object.entries(bases)) {
-    console.log(name, deployable.base);
     await registry.register(deployable.registryType, name, deployable.base);
   }
+
+  class TBoostCore extends BoostCore {
+    ContractAction(
+      options: DeployablePayloadOrAddress<ContractActionPayload>,
+      isBase?: boolean,
+    ) {
+      return new bases.ContractAction(
+        { config: this._config, account: this._account },
+        options,
+        isBase,
+      );
+    }
+    override EventAction(
+      options: DeployablePayloadOrAddress<EventActionPayload>,
+      isBase?: boolean,
+    ) {
+      return new bases.EventAction(
+        { config: this._config, account: this._account },
+        options,
+        isBase,
+      );
+    }
+    ERC721MintAction(
+      options: DeployablePayloadOrAddress<ERC721MintActionPayload>,
+      isBase?: boolean,
+    ) {
+      return new bases.ERC721MintAction(
+        { config: this._config, account: this._account },
+        options,
+        isBase,
+      );
+    }
+    override SimpleAllowList(
+      options: DeployablePayloadOrAddress<SimpleAllowListPayload>,
+      isBase?: boolean,
+    ) {
+      return new bases.SimpleAllowList(
+        { config: this._config, account: this._account },
+        options,
+        isBase,
+      );
+    }
+    override SimpleDenyList(
+      options: DeployablePayloadOrAddress<SimpleDenyListPayload>,
+      isBase?: boolean,
+    ) {
+      return new bases.SimpleDenyList(
+        { config: this._config, account: this._account },
+        options,
+        isBase,
+      );
+    }
+    SimpleBudget(options: DeployablePayloadOrAddress<SimpleBudgetPayload>) {
+      return new SimpleBudget(
+        { config: this._config, account: this._account },
+        options,
+      );
+    }
+    override ManagedBudget(
+      options: DeployablePayloadOrAddress<ManagedBudgetPayload>,
+    ) {
+      return new bases.ManagedBudget(
+        { config: this._config, account: this._account },
+        options,
+      );
+    }
+    VestingBudget(options: DeployablePayloadOrAddress<VestingBudgetPayload>) {
+      return new VestingBudget(
+        { config: this._config, account: this._account },
+        options,
+      );
+    }
+    override AllowListIncentive(options: AllowListIncentivePayload) {
+      return new bases.AllowListIncentive(
+        { config: this._config, account: this._account },
+        options,
+      );
+    }
+    override CGDAIncentive(options: CGDAIncentivePayload) {
+      return new bases.CGDAIncentive(
+        { config: this._config, account: this._account },
+        options,
+      );
+    }
+    override ERC20Incentive(options: ERC20IncentivePayload) {
+      return new bases.ERC20Incentive(
+        { config: this._config, account: this._account },
+        options,
+      );
+    }
+    ERC1155Incentive(options: ERC1155IncentivePayload) {
+      return new ERC1155Incentive(
+        { config: this._config, account: this._account },
+        options,
+      );
+    }
+    override PointsIncentive(options: PointsIncentivePayload) {
+      return new bases.PointsIncentive(
+        { config: this._config, account: this._account },
+        options,
+      );
+    }
+    override SignerValidator(
+      options: DeployablePayloadOrAddress<SignerValidatorPayload>,
+      isBase?: boolean,
+    ) {
+      return new bases.SignerValidator(
+        { config: this._config, account: this._account },
+        options,
+        isBase,
+      );
+    }
+    override ERC20VariableIncentive(
+      options: DeployablePayloadOrAddress<ERC20VariableIncentivePayload>,
+      isBase?: boolean,
+    ) {
+      return new bases.ERC20VariableIncentive(
+        { config: this._config, account: this._account },
+        options,
+        isBase,
+      );
+    }
+  }
+
+  const core = new TBoostCore({
+    ...options,
+    registryAddress: registry.assertValidAddress(),
+    protocolFeeReceiver: account.address,
+  });
+  await core.deploy();
 
   return {
     registry,

--- a/packages/sdk/test/zora-fork-mint.test.ts
+++ b/packages/sdk/test/zora-fork-mint.test.ts
@@ -68,7 +68,7 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
     test('should create a boost for incentivizing NFT minting', async () => {
       const { budget, erc20 } = budgets;
 
-      const { core, bases } = fixtures;
+      const { core } = fixtures;
 
       const client = new BoostCore({
         ...defaultOptions,
@@ -108,10 +108,7 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
         actionStepFour: eventActionStep, // Up to 4 action steps
       };
       // Initialize EventAction with the custom payload
-      const eventAction = new bases.EventAction(
-        defaultOptions,
-        eventActionPayload,
-      );
+      const eventAction = core.EventAction(eventActionPayload);
       // Create the boost using the custom EventAction
       await client.createBoost({
         protocolFee: 1n,
@@ -119,16 +116,16 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
         maxParticipants: 100n,
         budget: budget, // Use the ManagedBudget
         action: eventAction, // Pass the manually created EventAction
-        validator: new bases.SignerValidator(defaultOptions, {
+        validator: core.SignerValidator({
           signers: [owner, trustedSigner.account], // Whichever account we're going to sign with needs to be a signer
           validatorCaller: fixtures.core.assertValidAddress(), // Only core should be calling into the validate otherwise it's possible to burn signatures
         }),
-        allowList: new bases.SimpleAllowList(defaultOptions, {
+        allowList: core.SimpleAllowList({
           owner: owner,
           allowed: [owner],
         }),
         incentives: [
-          new bases.ERC20Incentive(defaultOptions, {
+          core.ERC20Incentive({
             asset: erc20.assertValidAddress(),
             reward: parseEther('1'),
             limit: 100n,


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/rabbitholegg/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description

When writing test/validation cases, you had to access base contract implementations like `createBoost({ allowList: new fixtures.bases.SimpleAllowList(options, {}) })` which is the more verbose, discouraged way to instantiate components and may be confusing to consumers reading the tests/examples as a reference.

support `createBoost({ allowList: core.SimpleAllowList({}) })` API in test cases so examples are 1:1 with real world production usage

💔 Thank you!
