### PR TITLE
[ADHOC] handle address filtering in not equal case

### DIFF
--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -533,6 +533,12 @@ export class EventAction extends DeployableTarget<
         return fieldValue === criteria.filterData;
 
       case FilterType.NOT_EQUAL:
+        if (criteria.fieldType === PrimitiveType.ADDRESS) {
+          return !isAddressEqual(
+            criteria.filterData,
+            `0x${fieldValue.slice(-40)}`,
+          );
+        }
         return fieldValue !== criteria.filterData;
 
       case FilterType.GREATER_THAN:


### PR DESCRIPTION
### Description
- 

When doing a `NOT_EQUAL` comparison with an address, it will always be true, as it is comparing against 32-byte address values.

This updates the logic in the `NOT_EQUAL` to mirror how addresses are treated in the `EQUALS` comparison. 

![CleanShot 2024-09-24 at 16 21 42@2x](https://github.com/user-attachments/assets/e0e4aba0-5b9f-4217-98c0-fc6a7b30c6ec)
