### PR TITLE
[BOOST-4710] Add regex event action

### DIFF
--- a/.changeset/great-bulldogs-buy.md
+++ b/.changeset/great-bulldogs-buy.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": minor
+---
+
+Implement support for non-indexed string parameters

--- a/.changeset/tiny-baboons-buy.md
+++ b/.changeset/tiny-baboons-buy.md
@@ -1,0 +1,6 @@
+---
+"@boostxyz/evm": minor
+"@boostxyz/sdk": minor
+---
+
+Support Regex filtering for Event Actions

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@nomicfoundation/hardhat-toolbox-viem": "^3.0.0",
     "@nomicfoundation/hardhat-viem": "2.0.4",
     "@types/node": "^20.11.24",
-    "@vitest/coverage-v8": "^1.6.0",
+    "@vitest/coverage-v8": "^2.1.1",
     "@wagmi/core": "^2.13.4",
     "arg": "^5.0.2",
     "danger": "^12.3.3",
@@ -51,7 +51,7 @@
     "typescript": "^5.3.3",
     "viem": "^2.20.1",
     "vite": "^5.2.13",
-    "vitest": "^1.6.0"
+    "vitest": "^2.1.1"
   },
   "pnpm": {
     "overrides": {

--- a/packages/evm/contracts/actions/AEventAction.sol
+++ b/packages/evm/contracts/actions/AEventAction.sol
@@ -23,7 +23,8 @@ abstract contract AEventAction is AAction {
         NOT_EQUAL,
         GREATER_THAN,
         LESS_THAN,
-        CONTAINS
+        CONTAINS,
+        REGEX
     }
 
     enum PrimitiveType {
@@ -37,8 +38,10 @@ abstract contract AEventAction is AAction {
     struct Criteria {
         FilterType filterType;
         PrimitiveType fieldType;
-        uint8 fieldIndex; // Where in the logs arg array the field is located
-        bytes filterData; // data fiels in case we need more complex filtering in the future - initially unused
+        // the parameter index in the event or function
+        uint8 fieldIndex;
+        // data fields in case we need more complex filtering; used with regex filters
+        bytes filterData;
     }
 
     struct ActionStep {

--- a/packages/evm/hardhat_build.config.cjs
+++ b/packages/evm/hardhat_build.config.cjs
@@ -1,7 +1,6 @@
 require('@nomicfoundation/hardhat-foundry');
 require('@nomicfoundation/hardhat-viem');
 require('@nomicfoundation/hardhat-ignition-viem');
-require('@nomicfoundation/hardhat-toolbox-viem');
 
 module.exports = {
   solidity: {

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -25,7 +25,7 @@
   "types": "./dist/generated.d.ts",
   "typings": "./dist/generated.d.ts",
   "scripts": {
-    "build": "npm run clean && npm run build:componentInterfaces && forge build --sizes && wagmi generate && vite build && tsc --build --emitDeclarationOnly --declaration --declarationMap --force",
+    "build": "npm run build:componentInterfaces && forge build --sizes && wagmi generate && vite build && tsc --build --emitDeclarationOnly --declaration --declarationMap --force",
     "build:componentInterfaces": "forge script script/solidity/ComponentInterface.s.sol",
     "clean": "forge clean && hardhat --config hardhat_build.config.cjs clean && rm -rf cache",
     "test": "forge test -vvv",

--- a/packages/sdk/hardhat.config.cjs
+++ b/packages/sdk/hardhat.config.cjs
@@ -1,5 +1,5 @@
 require('dotenv').config();
-require('@nomicfoundation/hardhat-toolbox-viem');
+
 module.exports = {
   networks: {
     ...(process.env.VITE_ALCHEMY_API_KEY

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -197,13 +197,16 @@
     "test:ci": "CI=true vitest --coverage",
     "typedoc": "npx typedoc --tsconfig ./tsconfig.build.json --sort required-first --sort visibility --sort kind"
   },
+  "dependencies": {
+    "@boostxyz/signatures": "workspace:*"
+  },
   "optionalDependencies": {
     "@boostxyz/evm": "workspace:*",
     "@boostxyz/signatures": "workspace:*"
   },
   "peerDependencies": {
     "@wagmi/core": "2",
-    "viem": "2",
-    "abitype": "1"
+    "abitype": "1",
+    "viem": "2"
   }
 }

--- a/packages/sdk/src/Actions/Action.test.ts
+++ b/packages/sdk/src/Actions/Action.test.ts
@@ -27,20 +27,24 @@ export function basicErc721TransferAction(
     actionClaimant: {
       chainid: 31337,
       signatureType: SignatureType.EVENT,
-      signature: selectors['Transfer(address,address,uint256)'] as Hex,
-      fieldIndex: 2,
+      signature: selectors[
+        'Transfer(address indexed,address indexed,uint256 indexed)'
+      ] as Hex,
+      fieldIndex: 1,
       targetContract: erc721.assertValidAddress(),
     },
     actionSteps: [
       {
         chainid: 31337,
-        signature: selectors['Transfer(address,address,uint256)'] as Hex,
+        signature: selectors[
+          'Transfer(address indexed,address indexed,uint256 indexed)'
+        ] as Hex,
         signatureType: SignatureType.EVENT,
         targetContract: erc721.assertValidAddress(),
         actionParameter: {
           filterType: FilterType.EQUAL,
           fieldType: PrimitiveType.ADDRESS,
-          fieldIndex: 2,
+          fieldIndex: 1,
           filterData: accounts[1].account,
         },
       },

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1,16 +1,18 @@
 import { selectors as eventSelectors } from '@boostxyz/signatures/events';
 import { selectors as funcSelectors } from '@boostxyz/signatures/functions';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
-import { type Hex, type Log, isAddress, pad, parseEther, toHex } from 'viem';
+import { type Address, type Hex, type Log, isAddress, pad, parseEther, toHex } from 'viem';
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import type { MockERC20 } from '../../test/MockERC20';
 import type { MockERC721 } from '../../test/MockERC721';
 import { accounts } from '../../test/accounts';
 import {
   type Fixtures,
+  type StringEmitterFixtures,
   defaultOptions,
   deployFixtures,
   fundErc20,
+  deployStringEmitterMock,
   fundErc721,
 } from '../../test/helpers';
 import {
@@ -21,10 +23,14 @@ import {
   SignatureType,
 } from './EventAction';
 
-let fixtures: Fixtures, erc721: MockERC721, erc20: MockERC20;
+let fixtures: Fixtures,
+  erc721: MockERC721,
+  erc20: MockERC20,
+  stringEmitterFixtures: StringEmitterFixtures;
 
 beforeAll(async () => {
   fixtures = await loadFixture(deployFixtures);
+  stringEmitterFixtures = await loadFixture(deployStringEmitterMock);
 });
 
 function basicErc721TransferAction(
@@ -122,6 +128,36 @@ function basicErc20MintFuncAction(erc20: MockERC20): EventActionPayloadSimple {
   };
 }
 
+function regexErc721TransferAction(
+  stringEmitterAddress: Address,
+  erc721: MockERC721,
+): EventActionPayloadSimple {
+  return {
+    actionClaimant: {
+      signatureType: SignatureType.EVENT,
+      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
+      fieldIndex: 2,
+      targetContract: erc721.assertValidAddress(),
+      chainid: defaultOptions.config.chains[0].id,
+    },
+    actionSteps: [
+      {
+        signature: eventSelectors['Info(string indexed emittedInfo)'] as Hex,
+        signatureType: SignatureType.EVENT,
+        actionType: 0,
+        targetContract: stringEmitterAddress,
+        chainid: defaultOptions.config.chains[0].id,
+        actionParameter: {
+          filterType: FilterType.REGEX,
+          fieldType: PrimitiveType.STRING,
+          fieldIndex: 1,
+          filterData: toHex('Hello'),
+        },
+      },
+    ],
+  };
+}
+
 function cloneFunctionAction20(fixtures: Fixtures, erc20: MockERC20) {
   return function cloneFunctionAction20() {
     return fixtures.registry.clone(
@@ -146,119 +182,184 @@ function cloneFunctionAction(fixtures: Fixtures, erc721: MockERC721) {
   };
 }
 
+function cloneStringEventAction(
+  fixtures: Fixtures,
+  stringEmitterAddress: Address,
+) {
+  const actionParams = regexErc721TransferAction(stringEmitterAddress, erc721);
+  return function cloneStringEventAction() {
+    return fixtures.registry.clone(
+      crypto.randomUUID(),
+      new fixtures.bases.EventAction(defaultOptions, actionParams),
+    );
+  };
+}
+
 describe('EventAction Event Selector', () => {
   beforeEach(async () => {
     erc721 = await loadFixture(fundErc721(defaultOptions));
   });
 
-  test('can successfully be deployed', async () => {
-    const action = new EventAction(
-      defaultOptions,
-      basicErc721TransferAction(erc721),
-    );
-    await action.deploy();
-    expect(isAddress(action.assertValidAddress())).toBe(true);
-  });
+  describe('basic transfer event', () => {
+    test('can successfully be deployed', async () => {
+      const action = new EventAction(
+        defaultOptions,
+        basicErc721TransferAction(erc721),
+      );
+      await action.deploy();
+      expect(isAddress(action.assertValidAddress())).toBe(true);
+    });
 
-  test('can get an action step', async () => {
-    const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    const step = await action.getActionStep(0);
-    if (!step) throw new Error('there should be an action step at this index');
-    step.targetContract = step.targetContract.toUpperCase() as Hex;
-    step.actionParameter.filterData =
-      step.actionParameter.filterData.toUpperCase() as Hex;
-    expect(step).toMatchObject({
-      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
-      signatureType: SignatureType.EVENT,
-      actionType: 0,
-      targetContract: erc721.assertValidAddress().toUpperCase(),
-      actionParameter: {
-        filterType: FilterType.EQUAL,
-        fieldType: PrimitiveType.ADDRESS,
+    test('can get an action step', async () => {
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      const step = await action.getActionStep(0);
+      if (!step)
+        throw new Error('there should be an action step at this index');
+      step.targetContract = step.targetContract.toUpperCase() as Hex;
+      step.actionParameter.filterData =
+        step.actionParameter.filterData.toUpperCase() as Hex;
+      expect(step).toMatchObject({
+        signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
+        signatureType: SignatureType.EVENT,
+        actionType: 0,
+        targetContract: erc721.assertValidAddress().toUpperCase(),
+        actionParameter: {
+          filterType: FilterType.EQUAL,
+          fieldType: PrimitiveType.ADDRESS,
+          fieldIndex: 2,
+          filterData: accounts[1].account.toUpperCase(),
+        },
+      });
+    });
+
+    test('can get all action steps', async () => {
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      const steps = await action.getActionSteps();
+      expect(steps.length).toBe(1);
+      const step = steps[0];
+      step.targetContract = step.targetContract.toUpperCase() as Hex;
+      step.actionParameter.filterData =
+        step.actionParameter.filterData.toUpperCase() as Hex;
+      expect(step).toMatchObject({
+        signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
+        signatureType: SignatureType.EVENT,
+        actionType: 0,
+        targetContract: erc721.assertValidAddress().toUpperCase(),
+        actionParameter: {
+          filterType: FilterType.EQUAL,
+          fieldType: PrimitiveType.ADDRESS,
+          fieldIndex: 2,
+          filterData: accounts[1].account.toUpperCase(),
+        },
+      });
+    });
+
+    test('can get the total number of action steps', async () => {
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      const count = await action.getActionStepsCount();
+      expect(count).toBe(1);
+    });
+
+    test('can get the action claimant', async () => {
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      const claimant = await action.getActionClaimant();
+      claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
+      expect(claimant).toMatchObject({
+        signatureType: SignatureType.EVENT,
+        signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
         fieldIndex: 2,
-        filterData: accounts[1].account.toUpperCase(),
-      },
+      });
     });
-  });
 
-  test('can get all action steps', async () => {
-    const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    const steps = await action.getActionSteps();
-    expect(steps.length).toBe(1);
-    const step = steps[0]!;
-    step.targetContract = step.targetContract.toUpperCase() as Hex;
-    step.actionParameter.filterData =
-      step.actionParameter.filterData.toUpperCase() as Hex;
-    expect(step).toMatchObject({
-      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
-      signatureType: SignatureType.EVENT,
-      actionType: 0,
-      targetContract: erc721.assertValidAddress().toUpperCase(),
-      actionParameter: {
-        filterType: FilterType.EQUAL,
-        fieldType: PrimitiveType.ADDRESS,
+    test('can get all action steps', async () => {
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      const steps = await action.getActionSteps();
+      expect(steps.length).toBe(1);
+      const step = steps[0];
+      step.targetContract = step.targetContract.toUpperCase() as Hex;
+      step.actionParameter.filterData =
+        step.actionParameter.filterData.toUpperCase() as Hex;
+      expect(step).toMatchObject({
+        signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
+        signatureType: SignatureType.EVENT,
+        actionType: 0,
+        targetContract: erc721.assertValidAddress().toUpperCase(),
+        actionParameter: {
+          filterType: FilterType.EQUAL,
+          fieldType: PrimitiveType.ADDRESS,
+          fieldIndex: 2,
+          filterData: accounts[1].account.toUpperCase(),
+        },
+      });
+    });
+
+    test('can get the total number of action steps', async () => {
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      const count = await action.getActionStepsCount();
+      expect(count).toBe(1);
+    });
+
+    test('can get the action claimant', async () => {
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      const claimant = await action.getActionClaimant();
+      claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
+      expect(claimant).toMatchObject({
+        signatureType: SignatureType.EVENT,
+        signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
         fieldIndex: 2,
-        filterData: accounts[1].account.toUpperCase(),
-      },
+        targetContract: erc721.assertValidAddress().toUpperCase(),
+      });
     });
-  });
 
-  test('can get the total number of action steps', async () => {
-    const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    const count = await action.getActionStepsCount();
-    expect(count).toBe(1);
-  });
-
-  test('can get the action claimant', async () => {
-    const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    const claimant = await action.getActionClaimant();
-    claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
-    expect(claimant).toMatchObject({
-      signatureType: SignatureType.EVENT,
-      signature: eventSelectors['Transfer(address,address,uint256)'] as Hex,
-      fieldIndex: 2,
-      targetContract: erc721.assertValidAddress().toUpperCase(),
+    test('with no logs, does not validate', async () => {
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      expect(await action.validateActionSteps()).toBe(false);
     });
-  });
 
-  test('with no logs, does not validate', async () => {
-    const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    expect(await action.validateActionSteps()).toBe(false);
-  });
+    test('with a correct log, validates', async () => {
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      const recipient = accounts[1].account;
+      await erc721.approve(recipient, 1n);
+      await erc721.transferFrom(defaultOptions.account.address, recipient, 1n);
+      expect(await action.validateActionSteps()).toBe(true);
+    });
 
-  test('with a correct log, validates', async () => {
-    const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    const recipient = accounts[1].account;
-    await erc721.approve(recipient, 1n);
-    await erc721.transferFrom(defaultOptions.account.address, recipient, 1n);
-    expect(await action.validateActionSteps()).toBe(true);
-  });
+    test('can supply your own logs to validate against', async () => {
+      const log = {
+        eventName: 'Transfer',
+        args: undefined,
+        address: erc721.assertValidAddress(),
+        blockHash:
+          '0xbf602f988260519805d032be46d6ff97fbefbee6924b21097074d6d0bc34eced',
+        blockNumber: 1203n,
+        data: '0x',
+        logIndex: 0,
+        removed: false,
+        topics: [
+          '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+          '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+          '0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8',
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        ],
+        transactionHash:
+          '0xff0e6ab0c4961ec14b7b40afec83ed7d7a77582683512a262e641d21f82efea5',
+        transactionIndex: 0,
+      } as Log;
+      const action = await loadFixture(cloneEventAction(fixtures, erc721));
+      expect(
+        await action.validateActionSteps({ logs: [log] }),
+      ).toBe(true);
+    });
 
-  test('can supply your own logs to validate against', async () => {
-    const log = {
-      eventName: 'Transfer',
-      args: undefined,
-      address: erc721.assertValidAddress(),
-      blockHash:
-        '0xbf602f988260519805d032be46d6ff97fbefbee6924b21097074d6d0bc34eced',
-      blockNumber: 1203n,
-      data: '0x',
-      logIndex: 0,
-      removed: false,
-      topics: [
-        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-        '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
-        '0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8',
-        '0x0000000000000000000000000000000000000000000000000000000000000001',
-      ],
-      transactionHash:
-        '0xff0e6ab0c4961ec14b7b40afec83ed7d7a77582683512a262e641d21f82efea5',
-      transactionIndex: 0,
-    } as Log;
-    const action = await loadFixture(cloneEventAction(fixtures, erc721));
-    expect(
-      await action.validateActionSteps({  logs: [log]  }),
-    ).toBe(true);
+    describe.todo('regex transfer event', () => {
+      test('can parse an emitted string event', async () => {
+        const action = await loadFixture(
+          cloneStringEventAction(fixtures, stringEmitterFixtures.address),
+        );
+        await stringEmitterFixtures.emitString('hello world');
+        expect(await action.validateActionSteps()).toBe(true);
+      });
+    });
   });
 });
 

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -328,8 +328,20 @@ export interface EventActionPayloadRaw {
   actionStepFour: ActionStep;
 }
 
+/**
+ * Array of event logs to pass into TxParams
+ * @export
+ * @typedef {EventLogs}
+ */
 export type EventLogs = GetLogsReturnType<AbiEvent, AbiEvent[], true>;
 
+/**
+ * Getter params from the event action contract
+ *
+ * @export
+ * @typedef {ReadEventActionParams}
+ * @param {fnName} fnName - The getter function name
+ */
 export type ReadEventActionParams<
   fnName extends ContractFunctionName<typeof eventActionAbi, 'pure' | 'view'>,
 > = ReadParams<typeof eventActionAbi, fnName>;

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -495,13 +495,38 @@ export async function deployStringEmitterMock(
       anonymous: false,
       inputs: [
         {
-          indexed: true,
+          indexed: false,
+          internalType: 'address',
+          name: 'messenger',
+          type: 'address',
+        },
+        {
+          indexed: false,
           internalType: 'string',
           name: 'emittedInfo',
           type: 'string',
         },
       ],
       name: 'Info',
+      type: 'event',
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'messenger',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          internalType: 'string',
+          name: 'emittedInfo',
+          type: 'string',
+        },
+      ],
+      name: 'InfoIndexed',
       type: 'event',
     },
     {
@@ -517,11 +542,24 @@ export async function deployStringEmitterMock(
       stateMutability: 'nonpayable',
       type: 'function',
     },
+    {
+      inputs: [
+        {
+          internalType: 'string',
+          name: 'infoToEmit',
+          type: 'string',
+        },
+      ],
+      name: 'storeIndexed',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function',
+    },
   ];
 
   // from sourcecode here: https://gist.github.com/topocount/f1bf0f53c41e53fd0824b250a92cfad7
   const stringEmitterBytecode =
-    '0x6080604052348015600e575f80fd5b506101cf8061001c5f395ff3fe608060405234801561000f575f80fd5b5060043610610029575f3560e01c8063131a06801461002d575b5f80fd5b610047600480360381019061004291906100fa565b610049565b005b8181604051610059929190610181565b60405180910390207f6d128f203c67be3b2d9bf1612fd59bdd6ae01f4f0d2ffedd05e76ab2a09b7f8a60405160405180910390a25050565b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f8083601f8401126100ba576100b9610099565b5b8235905067ffffffffffffffff8111156100d7576100d661009d565b5b6020830191508360018202830111156100f3576100f26100a1565b5b9250929050565b5f80602083850312156101105761010f610091565b5b5f83013567ffffffffffffffff81111561012d5761012c610095565b5b610139858286016100a5565b92509250509250929050565b5f81905092915050565b828183375f83830152505050565b5f6101688385610145565b935061017583858461014f565b82840190509392505050565b5f61018d82848661015d565b9150819050939250505056fea264697066735822122078b2f20733c3e7365d624d4e4b056202633440be09d47a294bad7c236c6d2a0c64736f6c634300081a0033';
+    '0x6080604052348015600e575f80fd5b506103078061001c5f395ff3fe608060405234801561000f575f80fd5b5060043610610034575f3560e01c8063131a06801461003857806319e951a414610054575b5f80fd5b610052600480360381019061004d9190610177565b610070565b005b61006e60048036038101906100699190610177565b6100af565b005b7fe46343e36b0721f173bdc76b8f25c08b04f417df09c27e1e83ba1980007fef8c3383836040516100a39392919061025b565b60405180910390a15050565b81816040516100bf9291906102b9565b60405180910390203373ffffffffffffffffffffffffffffffffffffffff167f883a883a9ea847654d33471b1e5fb2dea76a2cfc86a6cc7da6c14102800e4d0b60405160405180910390a35050565b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f8083601f84011261013757610136610116565b5b8235905067ffffffffffffffff8111156101545761015361011a565b5b6020830191508360018202830111156101705761016f61011e565b5b9250929050565b5f806020838503121561018d5761018c61010e565b5b5f83013567ffffffffffffffff8111156101aa576101a9610112565b5b6101b685828601610122565b92509250509250929050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6101eb826101c2565b9050919050565b6101fb816101e1565b82525050565b5f82825260208201905092915050565b828183375f83830152505050565b5f601f19601f8301169050919050565b5f61023a8385610201565b9350610247838584610211565b6102508361021f565b840190509392505050565b5f60408201905061026e5f8301866101f2565b818103602083015261028181848661022f565b9050949350505050565b5f81905092915050565b5f6102a0838561028b565b93506102ad838584610211565b82840190509392505050565b5f6102c5828486610295565b9150819050939250505056fea2646970667358221220bd08bcf727e6d8abeb6af5a11b4a0163eea7cea32d5df0c72d3df2ef0c8b836464736f6c634300081a0033';
 
   const stringEmitterAddress = await getDeployedContractAddress(
     config,
@@ -543,11 +581,23 @@ export async function deployStringEmitterMock(
     return writeContract(config, request);
   }
 
+  async function emitIndexedString(infoToEmit: string) {
+    const { request } = await simulateContract(config, {
+      address: stringEmitterAddress,
+      abi: stringEmitterAbi,
+      functionName: 'storeIndexed',
+      args: [infoToEmit],
+      account,
+    });
+    return writeContract(config, request);
+  }
+
   console.log('StringEmitter', stringEmitterAddress);
   return {
     address: stringEmitterAddress,
     abi: stringEmitterAbi,
     emitString,
+    emitIndexedString,
   };
 }
 

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -22,7 +22,7 @@ import ERC1155IncentiveArtifact from '@boostxyz/evm/artifacts/contracts/incentiv
 import PointsIncentiveArtifact from '@boostxyz/evm/artifacts/contracts/incentives/PointsIncentive.sol/PointsIncentive.json';
 import SignerValidatorArtifact from '@boostxyz/evm/artifacts/contracts/validators/SignerValidator.sol/SignerValidator.json';
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers';
-import { deployContract } from '@wagmi/core';
+import { deployContract, simulateContract, writeContract } from '@wagmi/core';
 import { type Address, type Hex, parseEther, zeroAddress } from 'viem';
 import {
   type ActionStep,
@@ -98,6 +98,9 @@ export const defaultOptions: DeployableTestOptions = {
 };
 
 export type Fixtures = Awaited<ReturnType<typeof deployFixtures>>;
+export type StringEmitterFixtures = Awaited<
+  ReturnType<typeof deployStringEmitterMock>
+>;
 export type BudgetFixtures = {
   budget: ManagedBudget;
   erc20: MockERC20;
@@ -480,6 +483,71 @@ export async function deployFixtures(
     registry,
     core,
     bases,
+  };
+}
+
+export async function deployStringEmitterMock(
+  options: DeployableTestOptions = defaultOptions,
+) {
+  const { config, account } = options;
+  const stringEmitterAbi = [
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'string',
+          name: 'emittedInfo',
+          type: 'string',
+        },
+      ],
+      name: 'Info',
+      type: 'event',
+    },
+    {
+      inputs: [
+        {
+          internalType: 'string',
+          name: 'infoToEmit',
+          type: 'string',
+        },
+      ],
+      name: 'store',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function',
+    },
+  ];
+
+  // from sourcecode here: https://gist.github.com/topocount/f1bf0f53c41e53fd0824b250a92cfad7
+  const stringEmitterBytecode =
+    '0x6080604052348015600e575f80fd5b506101cf8061001c5f395ff3fe608060405234801561000f575f80fd5b5060043610610029575f3560e01c8063131a06801461002d575b5f80fd5b610047600480360381019061004291906100fa565b610049565b005b8181604051610059929190610181565b60405180910390207f6d128f203c67be3b2d9bf1612fd59bdd6ae01f4f0d2ffedd05e76ab2a09b7f8a60405160405180910390a25050565b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f8083601f8401126100ba576100b9610099565b5b8235905067ffffffffffffffff8111156100d7576100d661009d565b5b6020830191508360018202830111156100f3576100f26100a1565b5b9250929050565b5f80602083850312156101105761010f610091565b5b5f83013567ffffffffffffffff81111561012d5761012c610095565b5b610139858286016100a5565b92509250509250929050565b5f81905092915050565b828183375f83830152505050565b5f6101688385610145565b935061017583858461014f565b82840190509392505050565b5f61018d82848661015d565b9150819050939250505056fea264697066735822122078b2f20733c3e7365d624d4e4b056202633440be09d47a294bad7c236c6d2a0c64736f6c634300081a0033';
+
+  const stringEmitterAddress = await getDeployedContractAddress(
+    config,
+    deployContract(config, {
+      abi: stringEmitterAbi,
+      bytecode: stringEmitterBytecode,
+      account,
+    }),
+  );
+
+  async function emitString(infoToEmit: string) {
+    const { request } = await simulateContract(config, {
+      address: stringEmitterAddress,
+      abi: stringEmitterAbi,
+      functionName: 'store',
+      args: [infoToEmit],
+      account,
+    });
+    return writeContract(config, request);
+  }
+
+  console.log('StringEmitter', stringEmitterAddress);
+  return {
+    address: stringEmitterAddress,
+    abi: stringEmitterAbi,
+    emitString,
   };
 }
 

--- a/packages/signatures/manifests/events.json
+++ b/packages/signatures/manifests/events.json
@@ -5,5 +5,6 @@
   "NameRegistered(string,bytes32,address,uint256,uint256,uint256)",
   "DelegateChanged(address,address,address)",
   "// Test signatures",
-  "Test(string)"
+  "Info(bytes)",
+  "Info(string indexed emittedInfo)"
 ]

--- a/packages/signatures/manifests/events.json
+++ b/packages/signatures/manifests/events.json
@@ -1,10 +1,10 @@
 [
   "// Begin common builtin event signatures",
-  "Transfer(address,address,uint256)",
+  "Transfer(address indexed,address indexed,uint256 indexed)",
   "Purchased(address,address,uint256,uint256,uint256)",
   "NameRegistered(string,bytes32,address,uint256,uint256,uint256)",
   "DelegateChanged(address,address,address)",
   "// Test signatures",
-  "Info(bytes)",
-  "Info(string indexed emittedInfo)"
+  "InfoIndexed(address indexed,string indexed)",
+  "Info(address,string)"
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 1.0.11(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
       '@nomicfoundation/hardhat-toolbox-viem':
         specifier: ^3.0.0
-        version: 3.0.0(d3njbiuuzhvy37jmuerp5waqtm)
+        version: 3.0.0(37xel52qjyqaeeq634okuvu2ze)
       '@nomicfoundation/hardhat-viem':
         specifier: 2.0.4
         version: 2.0.4(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))(typescript@5.3.3)(viem@2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(zod@3.22.4))(zod@3.22.4)
@@ -43,8 +43,8 @@ importers:
         specifier: ^20.11.24
         version: 20.12.11
       '@vitest/coverage-v8':
-        specifier: ^1.6.0
-        version: 1.6.0(vitest@1.6.0(@types/node@20.12.11)(terser@5.31.1))
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1(@types/node@20.12.11)(terser@5.31.1))
       '@wagmi/core':
         specifier: 2.13.0
         version: 2.13.0(@tanstack/query-core@5.32.0)(@types/react@18.3.0)(immer@10.0.2)(react@18.3.0)(typescript@5.3.3)(viem@2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@6.0.4)(zod@3.22.4))
@@ -91,8 +91,8 @@ importers:
         specifier: ^5.2.13
         version: 5.2.13(@types/node@20.12.11)(terser@5.31.1)
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.12.11)(terser@5.31.1)
+        specifier: ^2.1.1
+        version: 2.1.1(@types/node@20.12.11)(terser@5.31.1)
 
   examples/kitchen-sink:
     dependencies:
@@ -208,10 +208,10 @@ importers:
         version: 0.15.0(@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@2.0.6(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(bufferutil@4.0.8)(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(@nomicfoundation/hardhat-viem@2.0.3(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))(typescript@5.3.3)(viem@2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(zod@3.22.4))(zod@3.22.4))(@nomicfoundation/ignition-core@0.15.5(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))(viem@2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(zod@3.22.4))
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
-        version: 5.0.0(ch3ppnttsxpf23yxeu3qmt3kqu)
+        version: 5.0.0(xvfcxqqwruapje36ku545e2xhm)
       '@nomicfoundation/hardhat-toolbox-viem':
         specifier: ^3.0.0
-        version: 3.0.0(dnpr4ks7psuwualwpctgbplvxa)
+        version: 3.0.0(ds6ws52iggwie3zd4tgmpma3iy)
       '@nomicfoundation/hardhat-viem':
         specifier: ^2.0.2
         version: 2.0.3(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))(typescript@5.3.3)(viem@2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(zod@3.22.4))(zod@3.22.4)
@@ -2261,6 +2261,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@isaacs/ttlcache@1.4.1':
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
@@ -2310,6 +2314,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
@@ -2934,6 +2941,10 @@ packages:
     resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
     engines: {node: '>= 10.0.0'}
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
@@ -3470,25 +3481,44 @@ packages:
       react:
         optional: true
 
-  '@vitest/coverage-v8@1.6.0':
-    resolution: {integrity: sha512-KvapcbMY/8GYIG0rlwwOKCVNRc0OL20rrhFkg/CHNzncV03TE2XWvO5w9uZYoxNiMEBacAJt3unSOiZ7svePew==}
+  '@vitest/coverage-v8@2.1.1':
+    resolution: {integrity: sha512-md/A7A3c42oTT8JUHSqjP5uKTWJejzUW4jalpvs+rZ27gsURsMU8DEb+8Jf8C6Kj2gwfSHJqobDNBuoqlm0cFw==}
     peerDependencies:
-      vitest: 1.6.0
+      '@vitest/browser': 2.1.1
+      vitest: 2.1.1
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
-  '@vitest/expect@1.6.0':
-    resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
+  '@vitest/expect@2.1.1':
+    resolution: {integrity: sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==}
 
-  '@vitest/runner@1.6.0':
-    resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
+  '@vitest/mocker@2.1.1':
+    resolution: {integrity: sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==}
+    peerDependencies:
+      '@vitest/spy': 2.1.1
+      msw: ^2.3.5
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
-  '@vitest/snapshot@1.6.0':
-    resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
+  '@vitest/pretty-format@2.1.1':
+    resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
 
-  '@vitest/spy@1.6.0':
-    resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
+  '@vitest/runner@2.1.1':
+    resolution: {integrity: sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==}
 
-  '@vitest/utils@1.6.0':
-    resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
+  '@vitest/snapshot@2.1.1':
+    resolution: {integrity: sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==}
+
+  '@vitest/spy@2.1.1':
+    resolution: {integrity: sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==}
+
+  '@vitest/utils@2.1.1':
+    resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
 
   '@wagmi/cli@2.1.15':
     resolution: {integrity: sha512-mtTxbuCDRRSd/2tPAklM+4vFOq5E/0zS5OfLE3Ax2KcUWciOnjLJ0m6BAQ6HzqY9YfWo8DXa7UqxzUBkvPYltg==}
@@ -3679,10 +3709,6 @@ packages:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
 
-  acorn-walk@8.3.2:
-    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
@@ -3767,6 +3793,10 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
   antlr4ts@0.5.0-alpha.4:
     resolution: {integrity: sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==}
 
@@ -3815,8 +3845,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.15.2:
     resolution: {integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==}
@@ -4056,9 +4087,9 @@ packages:
     peerDependencies:
       chai: '>= 2.1.2 < 5'
 
-  chai@4.4.1:
-    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
-    engines: {node: '>=4'}
+  chai@5.1.1:
+    resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+    engines: {node: '>=12'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -4083,6 +4114,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -4420,6 +4455,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
@@ -4437,6 +4481,10 @@ packages:
 
   deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
+    engines: {node: '>=6'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
   deep-extend@0.6.0:
@@ -4507,10 +4555,6 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
-  diff-sequences@29.6.3:
-    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -4548,6 +4592,9 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -4568,6 +4615,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encode-utf8@1.0.3:
     resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
@@ -4903,6 +4953,10 @@ packages:
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
+  foreground-child@3.3.0:
+    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+    engines: {node: '>=14'}
+
   form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
     engines: {node: '>= 0.12'}
@@ -5034,6 +5088,10 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
 
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
@@ -5491,13 +5549,16 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.4:
-    resolution: {integrity: sha512-wHOoEsNJTVltaJp8eVkm8w+GVkVNHT2YDYo53YdzQEL2gWm1hBX5cGFR9hQJtuGLebidVX7et3+dmDZrmclduw==}
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jest-environment-node@29.7.0:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
@@ -5539,9 +5600,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.0:
-    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -5726,10 +5784,6 @@ packages:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
 
-  local-pkg@0.5.0:
-    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
-    engines: {node: '>=14'}
-
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
@@ -5844,8 +5898,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+  loupe@3.1.1:
+    resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
 
   lru-cache@10.2.2:
     resolution: {integrity: sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==}
@@ -5863,8 +5917,8 @@ packages:
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
-  magic-string@0.30.10:
-    resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
+  magic-string@0.30.11:
+    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
 
   magicast@0.3.4:
     resolution: {integrity: sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==}
@@ -6041,6 +6095,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mipd@0.0.7:
     resolution: {integrity: sha512-aAPZPNDQ3uMTdKbuO2YmAw2TxLHO0moa4YKAyETM/DTj5FloZo+a+8tU+iv4GmW+sOxKLSRwcSFuczk+Cpt6fg==}
@@ -6320,10 +6378,6 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
-
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
@@ -6359,6 +6413,9 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6425,6 +6482,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -6432,8 +6493,9 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
 
   pbkdf2@3.1.2:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
@@ -7192,6 +7254,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -7233,9 +7299,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-literal@2.1.0:
-    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
 
   strnum@1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
@@ -7323,9 +7386,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  test-exclude@6.0.0:
-    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
-    engines: {node: '>=8'}
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
 
   text-extensions@2.4.0:
     resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
@@ -7353,15 +7416,22 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
-  tinybench@2.8.0:
-    resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+  tinyexec@0.3.0:
+    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+
+  tinypool@1.0.1:
+    resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tmp@0.0.33:
@@ -7733,8 +7803,8 @@ packages:
       typescript:
         optional: true
 
-  vite-node@1.6.0:
-    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
+  vite-node@2.1.1:
+    resolution: {integrity: sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -7766,15 +7836,15 @@ packages:
       terser:
         optional: true
 
-  vitest@1.6.0:
-    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
+  vitest@2.1.1:
+    resolution: {integrity: sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.0
-      '@vitest/ui': 1.6.0
+      '@vitest/browser': 2.1.1
+      '@vitest/ui': 2.1.1
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -7851,8 +7921,8 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
-  why-is-node-running@2.2.2:
-    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
@@ -7881,6 +7951,10 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -10671,6 +10745,15 @@ snapshots:
   '@img/sharp-win32-x64@0.33.3':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@isaacs/ttlcache@1.4.1': {}
 
   '@istanbuljs/schema@0.1.3': {}
@@ -10732,6 +10815,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
@@ -11096,12 +11181,12 @@ snapshots:
       '@nomicfoundation/ethereumjs-rlp': 5.0.4
       ethereum-cryptography: 0.1.3
 
-  '@nomicfoundation/hardhat-chai-matchers@2.0.6(@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(chai@4.4.1)(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))':
+  '@nomicfoundation/hardhat-chai-matchers@2.0.6(@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(chai@5.1.1)(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))':
     dependencies:
       '@nomicfoundation/hardhat-ethers': 3.0.5(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
       '@types/chai-as-promised': 7.1.8
-      chai: 4.4.1
-      chai-as-promised: 7.1.1(chai@4.4.1)
+      chai: 5.1.1
+      chai-as-promised: 7.1.1(chai@5.1.1)
       deep-eql: 4.1.3
       ethers: 6.13.1(bufferutil@4.0.8)
       hardhat: 2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)
@@ -11185,7 +11270,7 @@ snapshots:
       ethereumjs-util: 7.1.5
       hardhat: 2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)
 
-  '@nomicfoundation/hardhat-toolbox-viem@3.0.0(d3njbiuuzhvy37jmuerp5waqtm)':
+  '@nomicfoundation/hardhat-toolbox-viem@3.0.0(37xel52qjyqaeeq634okuvu2ze)':
     dependencies:
       '@nomicfoundation/hardhat-ignition-viem': 0.15.0(@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@2.0.6(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(bufferutil@4.0.8)(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(@nomicfoundation/hardhat-viem@2.0.4(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))(typescript@5.3.3)(viem@2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(zod@3.22.4))(zod@3.22.4))(@nomicfoundation/ignition-core@0.15.5(bufferutil@4.0.8))(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))(viem@2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(zod@3.22.4))
       '@nomicfoundation/hardhat-network-helpers': 1.0.11(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
@@ -11195,8 +11280,8 @@ snapshots:
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.6
       '@types/node': 20.12.11
-      chai: 4.4.1
-      chai-as-promised: 7.1.1(chai@4.4.1)
+      chai: 5.1.1
+      chai-as-promised: 7.1.1(chai@5.1.1)
       hardhat: 2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)
       hardhat-gas-reporter: 1.0.10(bufferutil@4.0.8)(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
       solidity-coverage: 0.8.12(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
@@ -11204,7 +11289,7 @@ snapshots:
       typescript: 5.3.3
       viem: 2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@6.0.4)(zod@3.22.4)
 
-  '@nomicfoundation/hardhat-toolbox-viem@3.0.0(dnpr4ks7psuwualwpctgbplvxa)':
+  '@nomicfoundation/hardhat-toolbox-viem@3.0.0(ds6ws52iggwie3zd4tgmpma3iy)':
     dependencies:
       '@nomicfoundation/hardhat-ignition-viem': 0.15.0(@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@2.0.6(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(bufferutil@4.0.8)(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(@nomicfoundation/hardhat-viem@2.0.3(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))(typescript@5.3.3)(viem@2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(zod@3.22.4))(zod@3.22.4))(@nomicfoundation/ignition-core@0.15.5(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))(viem@2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(zod@3.22.4))
       '@nomicfoundation/hardhat-network-helpers': 1.0.11(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
@@ -11214,8 +11299,8 @@ snapshots:
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.6
       '@types/node': 20.12.11
-      chai: 4.4.1
-      chai-as-promised: 7.1.1(chai@4.4.1)
+      chai: 5.1.1
+      chai-as-promised: 7.1.1(chai@5.1.1)
       hardhat: 2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)
       hardhat-gas-reporter: 1.0.10(bufferutil@4.0.8)(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
       solidity-coverage: 0.8.12(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
@@ -11223,9 +11308,9 @@ snapshots:
       typescript: 5.3.3
       viem: 2.9.27(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@6.0.4)(zod@3.22.4)
 
-  '@nomicfoundation/hardhat-toolbox@5.0.0(ch3ppnttsxpf23yxeu3qmt3kqu)':
+  '@nomicfoundation/hardhat-toolbox@5.0.0(xvfcxqqwruapje36ku545e2xhm)':
     dependencies:
-      '@nomicfoundation/hardhat-chai-matchers': 2.0.6(@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(chai@4.4.1)(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
+      '@nomicfoundation/hardhat-chai-matchers': 2.0.6(@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(chai@5.1.1)(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
       '@nomicfoundation/hardhat-ethers': 3.0.5(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
       '@nomicfoundation/hardhat-ignition-ethers': 0.15.2(@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@2.0.6(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(bufferutil@4.0.8)(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)))(@nomicfoundation/ignition-core@0.15.5(bufferutil@4.0.8))(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
       '@nomicfoundation/hardhat-network-helpers': 1.0.11(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
@@ -11235,7 +11320,7 @@ snapshots:
       '@types/chai': 4.3.16
       '@types/mocha': 10.0.6
       '@types/node': 20.12.11
-      chai: 4.4.1
+      chai: 5.1.1
       ethers: 6.13.1(bufferutil@4.0.8)
       hardhat: 2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)
       hardhat-gas-reporter: 1.0.10(bufferutil@4.0.8)(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))
@@ -11492,6 +11577,9 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.4.1
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@popperjs/core@2.11.8': {}
 
@@ -12275,53 +12363,63 @@ snapshots:
       next: 14.2.3(@babel/core@7.24.7)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       react: 18.3.0
 
-  '@vitest/coverage-v8@1.6.0(vitest@1.6.0(@types/node@20.12.11)(terser@5.31.1))':
+  '@vitest/coverage-v8@2.1.1(vitest@2.1.1(@types/node@20.12.11)(terser@5.31.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.4
+      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      magic-string: 0.30.10
+      magic-string: 0.30.11
       magicast: 0.3.4
-      picocolors: 1.0.0
       std-env: 3.7.0
-      strip-literal: 2.1.0
-      test-exclude: 6.0.0
-      vitest: 1.6.0(@types/node@20.12.11)(terser@5.31.1)
+      test-exclude: 7.0.1
+      tinyrainbow: 1.2.0
+      vitest: 2.1.1(@types/node@20.12.11)(terser@5.31.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@1.6.0':
+  '@vitest/expect@2.1.1':
     dependencies:
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      chai: 4.4.1
+      '@vitest/spy': 2.1.1
+      '@vitest/utils': 2.1.1
+      chai: 5.1.1
+      tinyrainbow: 1.2.0
 
-  '@vitest/runner@1.6.0':
+  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.2.13(@types/node@20.12.11)(terser@5.31.1))':
     dependencies:
-      '@vitest/utils': 1.6.0
-      p-limit: 5.0.0
-      pathe: 1.1.2
-
-  '@vitest/snapshot@1.6.0':
-    dependencies:
-      magic-string: 0.30.10
-      pathe: 1.1.2
-      pretty-format: 29.7.0
-
-  '@vitest/spy@1.6.0':
-    dependencies:
-      tinyspy: 2.2.1
-
-  '@vitest/utils@1.6.0':
-    dependencies:
-      diff-sequences: 29.6.3
+      '@vitest/spy': 2.1.1
       estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
+      magic-string: 0.30.11
+    optionalDependencies:
+      vite: 5.2.13(@types/node@20.12.11)(terser@5.31.1)
+
+  '@vitest/pretty-format@2.1.1':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.1':
+    dependencies:
+      '@vitest/utils': 2.1.1
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.1':
+    dependencies:
+      '@vitest/pretty-format': 2.1.1
+      magic-string: 0.30.11
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.1':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.1':
+    dependencies:
+      '@vitest/pretty-format': 2.1.1
+      loupe: 3.1.1
+      tinyrainbow: 1.2.0
 
   '@wagmi/cli@2.1.15(bufferutil@4.0.8)(typescript@5.3.3)':
     dependencies:
@@ -12803,8 +12901,6 @@ snapshots:
 
   acorn-walk@8.2.0: {}
 
-  acorn-walk@8.3.2: {}
-
   acorn@8.10.0: {}
 
   acorn@8.11.3: {}
@@ -12874,6 +12970,8 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  ansi-styles@6.2.1: {}
+
   antlr4ts@0.5.0-alpha.4: {}
 
   anymatch@3.1.3:
@@ -12909,7 +13007,7 @@ snapshots:
 
   asap@2.0.6: {}
 
-  assertion-error@1.1.0: {}
+  assertion-error@2.0.1: {}
 
   ast-types@0.15.2:
     dependencies:
@@ -13156,20 +13254,18 @@ snapshots:
     dependencies:
       nofilter: 3.1.0
 
-  chai-as-promised@7.1.1(chai@4.4.1):
+  chai-as-promised@7.1.1(chai@5.1.1):
     dependencies:
-      chai: 4.4.1
+      chai: 5.1.1
       check-error: 1.0.3
 
-  chai@4.4.1:
+  chai@5.1.1:
     dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.3
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.0.8
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.1
+      pathval: 2.0.0
 
   chalk@2.4.2:
     dependencies:
@@ -13193,6 +13289,8 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  check-error@2.1.1: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -13594,6 +13692,10 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   decamelize@1.2.0: {}
 
   decamelize@4.0.0: {}
@@ -13605,6 +13707,8 @@ snapshots:
   deep-eql@4.1.3:
     dependencies:
       type-detect: 4.0.8
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -13650,8 +13754,6 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  diff-sequences@29.6.3: {}
-
   diff@4.0.2: {}
 
   diff@5.0.0: {}
@@ -13682,6 +13784,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
+
+  eastasianwidth@0.2.0: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -13718,6 +13822,8 @@ snapshots:
       minimalistic-crypto-utils: 1.0.1
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encode-utf8@1.0.3: {}
 
@@ -14203,6 +14309,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.0:
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 4.1.0
+
   form-data@2.5.1:
     dependencies:
       asynckit: 0.4.0
@@ -14329,6 +14440,15 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@5.0.15:
     dependencies:
@@ -14881,10 +15001,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.4:
+  istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -14893,6 +15013,12 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jest-environment-node@29.7.0:
     dependencies:
@@ -14961,8 +15087,6 @@ snapshots:
   js-sha3@0.8.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.0: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -15186,11 +15310,6 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
-  local-pkg@0.5.0:
-    dependencies:
-      mlly: 1.7.1
-      pkg-types: 1.1.1
-
   locate-path@2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -15285,7 +15404,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@2.3.7:
+  loupe@3.1.1:
     dependencies:
       get-func-name: 2.0.2
 
@@ -15304,9 +15423,9 @@ snapshots:
 
   lunr@2.3.9: {}
 
-  magic-string@0.30.10:
+  magic-string@0.30.11:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magicast@0.3.4:
     dependencies:
@@ -15579,6 +15698,8 @@ snapshots:
       brace-expansion: 2.0.1
 
   minimist@1.2.8: {}
+
+  minipass@7.1.2: {}
 
   mipd@0.0.7(typescript@5.3.3):
     optionalDependencies:
@@ -15871,10 +15992,6 @@ snapshots:
     dependencies:
       yocto-queue: 1.0.0
 
-  p-limit@5.0.0:
-    dependencies:
-      yocto-queue: 1.0.0
-
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
@@ -15904,6 +16021,8 @@ snapshots:
   p-try@1.0.0: {}
 
   p-try@2.2.0: {}
+
+  package-json-from-dist@1.0.1: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -15955,11 +16074,16 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.2.2
+      minipass: 7.1.2
+
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
 
-  pathval@1.1.1: {}
+  pathval@2.0.0: {}
 
   pbkdf2@3.1.2:
     dependencies:
@@ -16874,6 +16998,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -16909,10 +17039,6 @@ snapshots:
       is-hex-prefixed: 1.0.0
 
   strip-json-comments@3.1.1: {}
-
-  strip-literal@2.1.0:
-    dependencies:
-      js-tokens: 9.0.0
 
   strnum@1.0.5: {}
 
@@ -16994,11 +17120,11 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  test-exclude@6.0.0:
+  test-exclude@7.0.1:
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 7.2.3
-      minimatch: 3.1.2
+      glob: 10.4.5
+      minimatch: 9.0.5
 
   text-extensions@2.4.0: {}
 
@@ -17035,11 +17161,15 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
-  tinybench@2.8.0: {}
+  tinybench@2.9.0: {}
 
-  tinypool@0.8.4: {}
+  tinyexec@0.3.0: {}
 
-  tinyspy@2.2.1: {}
+  tinypool@1.0.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tmp@0.0.33:
     dependencies:
@@ -17355,12 +17485,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@1.6.0(@types/node@20.12.11)(terser@5.31.1):
+  vite-node@2.1.1(@types/node@20.12.11)(terser@5.31.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       pathe: 1.1.2
-      picocolors: 1.0.0
       vite: 5.2.13(@types/node@20.12.11)(terser@5.31.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -17382,33 +17511,33 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.31.1
 
-  vitest@1.6.0(@types/node@20.12.11)(terser@5.31.1):
+  vitest@2.1.1(@types/node@20.12.11)(terser@5.31.1):
     dependencies:
-      '@vitest/expect': 1.6.0
-      '@vitest/runner': 1.6.0
-      '@vitest/snapshot': 1.6.0
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      acorn-walk: 8.3.2
-      chai: 4.4.1
-      debug: 4.3.4(supports-color@8.1.1)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.10
+      '@vitest/expect': 2.1.1
+      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(vite@5.2.13(@types/node@20.12.11)(terser@5.31.1))
+      '@vitest/pretty-format': 2.1.1
+      '@vitest/runner': 2.1.1
+      '@vitest/snapshot': 2.1.1
+      '@vitest/spy': 2.1.1
+      '@vitest/utils': 2.1.1
+      chai: 5.1.1
+      debug: 4.3.7
+      magic-string: 0.30.11
       pathe: 1.1.2
-      picocolors: 1.0.0
       std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinybench: 2.8.0
-      tinypool: 0.8.4
+      tinybench: 2.9.0
+      tinyexec: 0.3.0
+      tinypool: 1.0.1
+      tinyrainbow: 1.2.0
       vite: 5.2.13(@types/node@20.12.11)(terser@5.31.1)
-      vite-node: 1.6.0(@types/node@20.12.11)(terser@5.31.1)
-      why-is-node-running: 2.2.2
+      vite-node: 2.1.1(@types/node@20.12.11)(terser@5.31.1)
+      why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.12.11
     transitivePeerDependencies:
       - less
       - lightningcss
+      - msw
       - sass
       - stylus
       - sugarss
@@ -17510,7 +17639,7 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
-  why-is-node-running@2.2.2:
+  why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
@@ -17541,6 +17670,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
This PR implements Regex event action support and also cleans up argument
handling. Now that we are strictly parsing logs with event ABIs, we are able
to support non-indexed params.


resolves BOOST-4752
resolves BOOST-4754
