### PR TITLE
[ADHOC] chore(sdk): enable tsconfig for test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 coverage
 .cache
 tsconfig.tsbuildinfo
+tsconfig.build.tsbuildinfo
 .DS_Store
 docs
 

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["dist", "build", "node_modules", "src/**/*.test.ts"],
   "references": [
     {
-      "path": "../sdk"
+      "path": "../sdk/tsconfig.build.json"
     },
     {
       "path": "../evm"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -185,7 +185,8 @@
     }
   },
   "scripts": {
-    "build": "vite build && tsc --build --emitDeclarationOnly --declaration --declarationMap --force",
+    "build": "vite build && tsc -p ./tsconfig.build.json --emitDeclarationOnly --declaration --declarationMap",
+    "typecheck": "tsc -p ./tsconfig.build.json --noEmit",
     "lint:ci": "npx biome ci",
     "lint": "npx biome check",
     "bench": "vitest bench",
@@ -194,7 +195,7 @@
     "dev": "vite build --watch",
     "test": "vitest dev",
     "test:ci": "CI=true vitest --coverage",
-    "typedoc": "npx typedoc --sort required-first --sort visibility --sort kind"
+    "typedoc": "npx typedoc --tsconfig ./tsconfig.build.json --sort required-first --sort visibility --sort kind"
   },
   "optionalDependencies": {
     "@boostxyz/evm": "workspace:*",

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "outDir": "dist"
   },
-  "exclude": ["dist", "build", "node_modules"],
+  "exclude": ["dist", "build", "node_modules", "src/**/*.test.ts"],
   "references": [
     {
       "path": "../evm"


### PR DESCRIPTION
The default tsconfig file is usually used in conjunction
with an IDE and a separate build config is used for the
build pipeline. The impetus for this is working with
monorepo package imports in test files was opaque before and
now they are transparent in the IDE.
