### PR TITLE
[BOOST-4729] fix(evm): make mulitiple CGDA claims impossible

### DIFF
--- a/packages/evm/contracts/incentives/CGDAIncentive.sol
+++ b/packages/evm/contracts/incentives/CGDAIncentive.sol
@@ -83,7 +83,8 @@ contract CGDAIncentive is AOwnable, ACGDAIncentive {
     /// @inheritdoc AIncentive
     /// @notice Claim the incentive
     function claim(address claimTarget, bytes calldata) external virtual override onlyOwner returns (bool) {
-        if (!_isClaimable(claimTarget)) revert NotClaimable();
+        if (!_isClaimable(claimTarget)) revert BoostError.ClaimFailed(claimTarget, hex"");
+        claimed[claimTarget] = true;
         claims++;
 
         // Calculate the current reward and update the state

--- a/packages/evm/test/incentives/CGDAIncentive.t.sol
+++ b/packages/evm/test/incentives/CGDAIncentive.t.sol
@@ -145,6 +145,16 @@ contract CGDAIncentiveTest is Test {
         assertEq(asset.balanceOf(address(incentive)), 0 ether);
     }
 
+    function test_no_duplicate_claim() public {
+        assertEq(incentive.currentReward(), 1 ether);
+        address claimer = makeAddr("zach zebra's zootopia");
+
+        incentive.claim(claimer, hex"");
+
+        vm.expectRevert(abi.encodeWithSelector(BoostError.ClaimFailed.selector, claimer, hex""));
+        incentive.claim(claimer, hex"");
+    }
+
     function test_claim_OutOfBudget() public {
         incentive.clawback(
             abi.encode(
@@ -158,7 +168,11 @@ contract CGDAIncentiveTest is Test {
         assertEq(incentive.currentReward(), 0 ether);
         assertEq(asset.balanceOf(address(incentive)), 0 ether);
 
-        vm.expectRevert(AIncentive.NotClaimable.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BoostError.ClaimFailed.selector, makeAddr("sam's soggy sandwich & soup shack"), hex""
+            )
+        );
         incentive.claim(makeAddr("sam's soggy sandwich & soup shack"), hex"");
 
         assertEq(incentive.currentReward(), 0 ether);

--- a/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
@@ -11,7 +11,6 @@ import {AIncentive, IBoostClaim} from "contracts/incentives/AIncentive.sol";
 import {ERC20VariableIncentive} from "contracts/incentives/ERC20VariableIncentive.sol";
 import {AERC20VariableIncentive} from "contracts/incentives/AERC20VariableIncentive.sol";
 
-
 import {ABudget} from "contracts/budgets/ABudget.sol";
 import {SimpleBudget} from "contracts/budgets/SimpleBudget.sol";
 


### PR DESCRIPTION
While other areas in the stack could potentially prevent this issue,
including the SignerValidator, which tracks claim increments,
this contract was designed to limit claims to 1 for each address.
