### PR TITLE
[BOOST-4730] fix(evm): revert createBoost if no Validator

### DIFF
--- a/packages/evm/contracts/BoostCore.sol
+++ b/packages/evm/contracts/BoostCore.sol
@@ -131,6 +131,11 @@ contract BoostCore is Ownable, ReentrancyGuard {
                 ? boost.action.supportsInterface(type(AValidator).interfaceId) ? address(boost.action) : address(0)
                 : _makeTarget(type(AValidator).interfaceId, payload_.validator, true)
         );
+
+        if (address(boost.validator) == address(0)) {
+            revert BoostError.InvalidInstance(type(AValidator).interfaceId, address(0));
+        }
+
         emit BoostCreated(
             _boosts.length - 1,
             boost.owner,

--- a/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
+++ b/packages/evm/test/incentives/ERC20VariableIncentive.t.sol
@@ -11,7 +11,6 @@ import {AIncentive, IBoostClaim} from "contracts/incentives/AIncentive.sol";
 import {ERC20VariableIncentive} from "contracts/incentives/ERC20VariableIncentive.sol";
 import {AERC20VariableIncentive} from "contracts/incentives/AERC20VariableIncentive.sol";
 
-
 import {ABudget} from "contracts/budgets/ABudget.sol";
 import {SimpleBudget} from "contracts/budgets/SimpleBudget.sol";
 


### PR DESCRIPTION
We should prevent deployment of unclaimable boosts by reverting if no
validator is supplied to `createBoost`
