### PR TITLE
[BOOST-4772] Refactor Budget Methods

### DIFF
--- a/.changeset/silver-bobcats-switch.md
+++ b/.changeset/silver-bobcats-switch.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+refactor budget methods to make assets have zero address as the default value

--- a/packages/sdk/src/Budgets/ManagedBudget.test.ts
+++ b/packages/sdk/src/Budgets/ManagedBudget.test.ts
@@ -42,8 +42,8 @@ describe('ManagedBudget', () => {
     const budget = await loadFixture(
       freshManagedBudget(defaultOptions, fixtures),
     );
-    const one = accounts.at(1)!.account;
-    const two = accounts.at(2)!.account;
+    const one = accounts[1].account;
+    const two = accounts[2].account;
     await budget.setAuthorized([one, two], [true, true]);
     expect(await budget.hasAllRoles(one, ManagedBudgetRoles.ADMIN)).toBe(false);
     expect(await budget.hasAllRoles(one, ManagedBudgetRoles.MANAGER)).toBe(
@@ -58,8 +58,8 @@ describe('ManagedBudget', () => {
     const budget = await loadFixture(
       freshManagedBudget(defaultOptions, fixtures),
     );
-    const admin = accounts.at(1)!.account;
-    const manager = accounts.at(2)!.account;
+    const admin = accounts[1].account;
+    const manager = accounts[2].account;
     await budget.grantRoles(
       [admin, manager],
       [ManagedBudgetRoles.ADMIN, ManagedBudgetRoles.MANAGER],
@@ -76,8 +76,8 @@ describe('ManagedBudget', () => {
     const budget = await loadFixture(
       freshManagedBudget(defaultOptions, fixtures),
     );
-    const admin = accounts.at(1)!.account;
-    const manager = accounts.at(2)!.account;
+    const admin = accounts[1].account;
+    const manager = accounts[2].account;
     await budget.grantRoles(
       [admin, manager],
       [ManagedBudgetRoles.ADMIN, ManagedBudgetRoles.MANAGER],
@@ -115,7 +115,7 @@ describe('ManagedBudget', () => {
     const budget = await loadFixture(
       freshManagedBudget(defaultOptions, fixtures),
     );
-    expect(await budget.available(zeroAddress)).toBe(0n);
+    expect(await budget.available()).toBe(0n);
   });
 
   describe('can allocate', () => {
@@ -136,7 +136,7 @@ describe('ManagedBudget', () => {
           value: parseEther('1.0'),
         },
       );
-      expect(await budget.available(zeroAddress)).toBe(parseEther('1.0'));
+      expect(await budget.available()).toBe(parseEther('1.0'));
     });
 
     test('erc20', async () => {
@@ -186,7 +186,7 @@ describe('ManagedBudget', () => {
         target: defaultOptions.account.address,
       });
 
-      expect(await budget.available(zeroAddress)).toBe(0n);
+      expect(await budget.available()).toBe(0n);
     });
 
     test('erc20 assets', async () => {

--- a/packages/sdk/src/Budgets/ManagedBudget.ts
+++ b/packages/sdk/src/Budgets/ManagedBudget.ts
@@ -682,13 +682,13 @@ export class ManagedBudget extends DeployableTarget<
    * If a tokenId is provided, get the total amount of ERC1155 assets allocated to the budget, including any that have been distributed
    *
    * @public
-   * @param {Address} asset - The address of the asset
+   * @param {Address} [asset="0x0000000000000000000000000000000000000000"] - The address of the asset
    * @param {?(bigint | undefined)} [tokenId] - The ID of the token
    * @param {?ReadParams<typeof managedBudgetAbi, 'total'>} [params]
    * @returns {Promise<bigint>} - The total amount of assets
    */
   public total(
-    asset: Address,
+    asset: Address = zeroAddress,
     tokenId?: bigint | undefined,
     params?: ReadParams<typeof managedBudgetAbi, 'total'>,
   ) {
@@ -705,13 +705,13 @@ export class ManagedBudget extends DeployableTarget<
    * If a tokenId is provided, get the amount of ERC1155 assets available for distribution from the budget
    *
    * @public
-   * @param {Address} asset
+   * @param {Address} [asset="0x0000000000000000000000000000000000000000"]
    * @param {?(bigint | undefined)} [tokenId]
    * @param {?ReadParams<typeof managedBudgetAbi, 'available'>} [params]
    * @returns {Promise<bigint>} - The amount of assets available
    */
   public available(
-    asset: Address,
+    asset: Address = zeroAddress,
     tokenId?: bigint | undefined,
     params?: ReadParams<typeof managedBudgetAbi, 'available'>,
   ) {
@@ -728,13 +728,13 @@ export class ManagedBudget extends DeployableTarget<
    * If a tokenId is provided, get the amount of ERC1155 assets that have been distributed from the budget
    *
    * @public
-   * @param {Address} asset
+   * @param {Address} [asset="0x0000000000000000000000000000000000000000"]
    * @param {?(bigint | undefined)} [tokenId]
    * @param {?ReadParams<typeof managedBudgetAbi, 'distributed'>} [params]
    * @returns {Promise<bigint>} - The amount of assets distributed
    */
   public distributed(
-    asset: Address,
+    asset: Address = zeroAddress,
     tokenId?: bigint | undefined,
     params?: ReadParams<typeof managedBudgetAbi, 'distributed'>,
   ) {

--- a/packages/sdk/src/Budgets/SimpleBudget.test.ts
+++ b/packages/sdk/src/Budgets/SimpleBudget.test.ts
@@ -50,7 +50,7 @@ describe.skip('SimpleBudget', () => {
 
   test('can have no initial balance', async () => {
     const budget = await loadFixture(freshBudget(defaultOptions, fixtures));
-    expect(await budget.available(zeroAddress)).toBe(0n);
+    expect(await budget.available()).toBe(0n);
   });
 
   describe('can allocate', () => {
@@ -71,7 +71,7 @@ describe.skip('SimpleBudget', () => {
           value: parseEther('1.0'),
         },
       );
-      expect(await budget.available(zeroAddress)).toBe(parseEther('1.0'));
+      expect(await budget.available()).toBe(parseEther('1.0'));
     });
 
     test('erc20', async () => {
@@ -121,7 +121,7 @@ describe.skip('SimpleBudget', () => {
         target: defaultOptions.account.address,
       });
 
-      expect(await budget.available(zeroAddress)).toBe(0n);
+      expect(await budget.available()).toBe(0n);
     });
 
     test('erc20 assets', async () => {

--- a/packages/sdk/src/Budgets/SimpleBudget.ts
+++ b/packages/sdk/src/Budgets/SimpleBudget.ts
@@ -441,13 +441,13 @@ export class SimpleBudget extends DeployableTarget<
    * If a tokenId is provided, get the total amount of ERC1155 assets allocated to the budget, including any that have been distributed
    *
    * @public
-   * @param {Address} asset - The address of the asset
+   * @param {Address} [asset="0x0000000000000000000000000000000000000000"] - The address of the asset
    * @param {?(bigint | undefined)} [tokenId] - The ID of the token
    * @param {?ReadParams<typeof simpleBudgetAbi, 'total'>} [params]
    * @returns {Promise<bigint>} - The total amount of assets
    */
   public total(
-    asset: Address,
+    asset: Address = zeroAddress,
     tokenId?: bigint | undefined,
     params?: ReadParams<typeof simpleBudgetAbi, 'total'>,
   ) {
@@ -464,13 +464,13 @@ export class SimpleBudget extends DeployableTarget<
    * If a tokenId is provided, get the amount of ERC1155 assets available for distribution from the budget
    *
    * @public
-   * @param {Address} asset
+   * @param {Address} [asset="0x0000000000000000000000000000000000000000"]
    * @param {?(bigint | undefined)} [tokenId]
    * @param {?ReadParams<typeof simpleBudgetAbi, 'available'>} [params]
    * @returns {Promise<bigint>} - The amount of assets available
    */
   public available(
-    asset: Address,
+    asset: Address = zeroAddress,
     tokenId?: bigint | undefined,
     params?: ReadParams<typeof simpleBudgetAbi, 'available'>,
   ) {
@@ -487,13 +487,13 @@ export class SimpleBudget extends DeployableTarget<
    * If a tokenId is provided, get the amount of ERC1155 assets that have been distributed from the budget
    *
    * @public
-   * @param {Address} asset
+   * @param {Address} [asset="0x0000000000000000000000000000000000000000"]
    * @param {?(bigint | undefined)} [tokenId]
    * @param {?ReadParams<typeof simpleBudgetAbi, 'distributed'>} [params]
    * @returns {Promise<bigint>} - The amount of assets distributed
    */
   public distributed(
-    asset: Address,
+    asset: Address = zeroAddress,
     tokenId?: bigint | undefined,
     params?: ReadParams<typeof simpleBudgetAbi, 'distributed'>,
   ) {

--- a/packages/sdk/src/Budgets/VestingBudget.test.ts
+++ b/packages/sdk/src/Budgets/VestingBudget.test.ts
@@ -53,7 +53,7 @@ describe.skip('VestingBudget', () => {
     const budget = await loadFixture(
       freshVestingBudget(defaultOptions, fixtures),
     );
-    expect(await budget.available(zeroAddress)).toBe(0n);
+    expect(await budget.available()).toBe(0n);
   });
 
   describe('can allocate', () => {
@@ -73,7 +73,7 @@ describe.skip('VestingBudget', () => {
           value: parseEther('1.0'),
         },
       );
-      expect(await budget.available(zeroAddress)).toBe(parseEther('1.0'));
+      expect(await budget.available()).toBe(parseEther('1.0'));
     });
 
     test('erc20', async () => {
@@ -105,7 +105,7 @@ describe.skip('VestingBudget', () => {
         target: defaultOptions.account.address,
       });
 
-      expect(await budget.available(zeroAddress)).toBe(0n);
+      expect(await budget.available()).toBe(0n);
     });
 
     test('erc20 assets', async () => {

--- a/packages/sdk/src/Budgets/VestingBudget.ts
+++ b/packages/sdk/src/Budgets/VestingBudget.ts
@@ -480,12 +480,12 @@ export class VestingBudget extends DeployableTarget<
    * This is equal to the sum of the total current balance and the total distributed amount
    *
    * @public
-   * @param {Address} asset -  The address of the asset (or the zero address for native assets)
+   * @param {Address} [asset="0x0000000000000000000000000000000000000000"] -  The address of the asset (or the zero address for native assets)
    * @param {?ReadParams<typeof vestingBudgetAbi, 'total'>} [params]
    * @returns {Promise<bigint>}
    */
   public total(
-    asset: Address,
+    asset: Address = zeroAddress,
     params?: ReadParams<typeof vestingBudgetAbi, 'total'>,
   ) {
     return readVestingBudgetTotal(this._config, {
@@ -501,12 +501,12 @@ export class VestingBudget extends DeployableTarget<
    * This is equal to the total vested amount minus any already distributed
    *
    * @public
-   * @param {Address} asset -  The address of the asset (or the zero address for native assets)
+   * @param {Address} [asset="0x0000000000000000000000000000000000000000"] -  The address of the asset (or the zero address for native assets)
    * @param {?ReadParams<typeof vestingBudgetAbi, 'available'>} [params]
    * @returns {Promise<bigint>} - The amount of assets currently available for distribution
    */
   public available(
-    asset: Address,
+    asset: Address = zeroAddress,
     params?: ReadParams<typeof vestingBudgetAbi, 'available'>,
   ) {
     return readVestingBudgetAvailable(this._config, {
@@ -521,12 +521,12 @@ export class VestingBudget extends DeployableTarget<
    * Get the amount of assets that have been distributed from the budget
    *
    * @public
-   * @param {Address} asset
+   * @param {Address} [asset="0x0000000000000000000000000000000000000000"]
    * @param {?ReadParams<typeof vestingBudgetAbi, 'distributed'>} [params]
    * @returns {Promise<bigint>} - The amount of assets distributed
    */
   public distributed(
-    asset: Address,
+    asset: Address = zeroAddress,
     params?: ReadParams<typeof vestingBudgetAbi, 'distributed'>,
   ) {
     return readVestingBudgetDistributed(this._config, {


### PR DESCRIPTION
### Description
On all methods for the various Budget Accounts in the SDK, we should make the `asset` param default to the zero address. This allows the SDK functions to fetch the native tokens without having to explicitly pass in the zero address.

Addresses this issue: https://github.com/rabbitholegg/boost-protocol/issues/116