### PR TITLE
[ADHOC] refactor(sdk): import deployed addresses from evm, utility to pick base addresses off config

### DIFF
--- a/.changeset/shaggy-students-end.md
+++ b/.changeset/shaggy-students-end.md
@@ -1,0 +1,6 @@
+---
+"@boostxyz/evm": minor
+"@boostxyz/sdk": minor
+---
+
+refactor base to bases in boost targets, resolve base address from config, and default to sepolia for now

--- a/examples/next/public/site.webmanifest
+++ b/examples/next/public/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -32,7 +32,7 @@ import {
 import { createConfig, deployContract } from '@wagmi/core';
 import type { Hex } from 'viem';
 import { http, createWalletClient } from 'viem';
-import { privateKeyToAccount } from 'viem/accounts';
+import { type Address, privateKeyToAccount } from 'viem/accounts';
 import * as _chains from 'viem/chains';
 import type { Command } from '../utils';
 
@@ -82,6 +82,8 @@ export const deploy: Command<DeployResult> = async function deploy(opts) {
   });
 
   const options: DeployableOptions = { config, account };
+
+  const chainId = chain!.id!;
 
   const registry = await (
     new BoostRegistry({
@@ -236,48 +238,72 @@ export const deploy: Command<DeployResult> = async function deploy(opts) {
     //   public static override base = erc721MintActionBase;
     // },
     EventAction: class TEventAction extends EventAction {
-      public static override base = eventActionBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: eventActionBase,
+      } as Record<number, Address>;
     },
     SimpleAllowList: class TSimpleAllowList extends SimpleAllowList {
-      public static override base = simpleAllowListBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: simpleAllowListBase,
+      } as Record<number, Address>;
     },
     SimpleDenyList: class TSimpleDenyList extends SimpleDenyList {
-      public static override base = simpleDenyListBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: simpleDenyListBase,
+      } as Record<number, Address>;
     },
     // SimpleBudget: class TSimpleBudget extends SimpleBudget {
     //   public static override base = simpleBudgetBase;
     // },
     ManagedBudget: class TSimpleBudget extends ManagedBudget {
-      public static override base = managedBudgetBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: managedBudgetBase,
+      } as Record<number, Address>;
     },
     // VestingBudget: class TVestingBudget extends VestingBudget {
     //   public static override base = vestingBudgetBase;
     // },
     AllowListIncentive: class TAllowListIncentive extends AllowListIncentive {
-      public static override base = allowListIncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: allowListIncentiveBase,
+      } as Record<number, Address>;
     },
     CGDAIncentive: class TCGDAIncentive extends CGDAIncentive {
-      public static override base = cgdaIncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: cgdaIncentiveBase,
+      } as Record<number, Address>;
     },
     ERC20Incentive: class TERC20Incentive extends ERC20Incentive {
-      public static override base = erc20IncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: erc20IncentiveBase,
+      } as Record<number, Address>;
     },
     ERC20VariableIncentive: class TERC20VariableIncentive extends ERC20VariableIncentive {
-      public static override base = erc20VariableIncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: erc20VariableIncentiveBase,
+      } as Record<number, Address>;
     },
     // ERC1155Incentive: class TERC1155Incentive extends ERC1155Incentive {
     //   public static override base = erc1155IncentiveBase;
     // },
     PointsIncentive: class TPointsIncentive extends PointsIncentive {
-      public static override base = pointsIncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: pointsIncentiveBase,
+      } as Record<number, Address>;
     },
     SignerValidator: class TSignerValidator extends SignerValidator {
-      public static override base = signerValidatorBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: signerValidatorBase,
+      } as Record<number, Address>;
     },
   };
 
   for (const [name, deployable] of Object.entries(bases)) {
-    await registry.register(deployable.registryType, name, deployable.base);
+    await registry.register(
+      deployable.registryType,
+      name,
+      deployable.bases[chainId],
+    );
   }
 
   return {

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -18,7 +18,8 @@
       "types": "./dist/generated.d.ts"
     },
     "./artifacts/contracts/*.json": "./artifacts/contracts/*.json",
-    "./deploys/componentInterfaces.json": "./deploys/componentInterfaces.json"
+    "./deploys/componentInterfaces.json": "./deploys/componentInterfaces.json",
+    "./deploys/*.json": "./deploys/*.json"
   },
   "main": "./dist/generated.cjs",
   "module": "./dist/generated.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -51,6 +51,7 @@
       "node": "./dist/transfers.js",
       "types": "./dist/transfers.d.ts"
     },
+    "./deployments.json": "./dist/deployments.json",
     "./Boost": {
       "require": "./dist/Boost.cjs",
       "import": "./dist/Boost.js",
@@ -185,14 +186,14 @@
     }
   },
   "scripts": {
-    "build": "vite build && tsc -p ./tsconfig.build.json --emitDeclarationOnly --declaration --declarationMap",
+    "build": "mkdir -p dist && vite build && tsc -p ./tsconfig.build.json --emitDeclarationOnly --declaration --declarationMap",
     "typecheck": "tsc -p ./tsconfig.build.json --noEmit",
     "lint:ci": "npx biome ci",
     "lint": "npx biome check",
     "bench": "vitest bench",
     "bench:ci": "CI=true vitest bench",
     "clean": "rm -rf dist",
-    "dev": "vite build --watch",
+    "dev": "mkdir -p dist && vite build --watch",
     "test": "vitest dev",
     "test:ci": "CI=true vitest --coverage",
     "typedoc": "npx typedoc --tsconfig ./tsconfig.build.json --sort required-first --sort visibility --sort kind"

--- a/packages/sdk/src/Actions/ContractAction.ts
+++ b/packages/sdk/src/Actions/ContractAction.ts
@@ -17,6 +17,7 @@ import {
   encodeAbiParameters,
   parseAbiParameters,
 } from 'viem';
+import {} from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -99,10 +100,11 @@ export class ContractAction<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_CONTRACT_ACTION_BASE;
+  public static override bases: Record<number, Address> = {
+    31337: import.meta.env.VITE_CONTRACT_ACTION_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Actions/ERC721MintAction.ts
+++ b/packages/sdk/src/Actions/ERC721MintAction.ts
@@ -15,6 +15,7 @@ import {
   encodeAbiParameters,
   toHex,
 } from 'viem';
+import {} from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -77,10 +78,11 @@ export class ERC721MintAction extends ContractAction<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_ERC721_MINT_ACTION_BASE;
+  public static override bases: Record<number, Address> = {
+    31337: import.meta.env.VITE_ERC721_MINT_ACTION_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -27,6 +27,7 @@ import {
   trim,
 } from 'viem';
 import { getLogs } from 'viem/actions';
+import { EventAction as EventActionBases } from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -373,9 +374,12 @@ export class EventAction extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env.VITE_EVENT_ACTION_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(EventActionBases as Record<number, Address>),
+    31337: import.meta.env.VITE_EVENT_ACTION_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/AllowLists/AllowList.test.ts
+++ b/packages/sdk/src/AllowLists/AllowList.test.ts
@@ -52,7 +52,7 @@ describe('AllowList', () => {
     ).toBeInstanceOf(SimpleAllowList);
   });
 
-  test('can automatically instantiate SimpleAllowList given an address', async () => {
+  test('can automatically instantiate SimpleDenyList given an address', async () => {
     const _allowList = await loadFixture(freshDenyList(fixtures));
     expect(
       await allowListFromAddress(

--- a/packages/sdk/src/AllowLists/SimpleAllowList.ts
+++ b/packages/sdk/src/AllowLists/SimpleAllowList.ts
@@ -16,6 +16,7 @@ import {
   zeroAddress,
   zeroHash,
 } from 'viem';
+import { SimpleAllowList as SimpleAllowListBases } from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -92,10 +93,12 @@ export class SimpleAllowList extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_SIMPLE_ALLOWLIST_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(SimpleAllowListBases as Record<number, Address>),
+    31337: import.meta.env.VITE_SIMPLE_ALLOWLIST_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/AllowLists/SimpleDenyList.ts
+++ b/packages/sdk/src/AllowLists/SimpleDenyList.ts
@@ -14,6 +14,7 @@ import {
   zeroAddress,
   zeroHash,
 } from 'viem';
+import { SimpleDenyList as SimpleDenyListBases } from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -83,10 +84,12 @@ export class SimpleDenyList<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_SIMPLE_DENYLIST_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(SimpleDenyListBases as Record<number, Address>),
+    31337: import.meta.env.VITE_SIMPLE_DENYLIST_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/BoostCore.test.ts
+++ b/packages/sdk/src/BoostCore.test.ts
@@ -29,13 +29,9 @@ describe('BoostCore', () => {
 
   test('can get the total number of boosts', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
 
     const { budget, erc20 } = budgets;
-    await client.createBoost({
+    await core.createBoost({
       protocolFee: 1n,
       referralFee: 2n,
       maxParticipants: 100n,
@@ -63,17 +59,13 @@ describe('BoostCore', () => {
         }),
       ],
     });
-    expect(await client.getBoostCount()).toBe(1n);
+    expect(await core.getBoostCount()).toBe(1n);
   });
 
   test('can successfully create a boost using all base contract implementations', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
     const { budget, erc20 } = budgets;
-    const boost = await client.createBoost({
+    const boost = await core.createBoost({
       protocolFee: 1n,
       referralFee: 2n,
       maxParticipants: 100n,
@@ -101,7 +93,7 @@ describe('BoostCore', () => {
         }),
       ],
     });
-    const onChainBoost = await client.readBoost(boost.id);
+    const onChainBoost = await core.readBoost(boost.id);
 
     expect(boost.owner).toBe(onChainBoost.owner);
     expect(boost.protocolFee).toBe(onChainBoost.protocolFee);
@@ -155,12 +147,8 @@ describe('BoostCore', () => {
 
   test('can read the raw on chain representation of a boost', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
     const { budget, erc20 } = budgets;
-    const _boost = await client.createBoost({
+    const _boost = await core.createBoost({
       protocolFee: 1n,
       referralFee: 2n,
       maxParticipants: 100n,
@@ -188,7 +176,7 @@ describe('BoostCore', () => {
         }),
       ],
     });
-    const boost = await client.readBoost(_boost.id);
+    const boost = await core.readBoost(_boost.id);
     expect(boost.protocolFee).toBe(1001n);
     expect(boost.referralFee).toBe(1002n);
     expect(boost.maxParticipants).toBe(100n);
@@ -203,10 +191,6 @@ describe('BoostCore', () => {
 
   test('can reuse an existing action', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
     const { budget, erc20 } = budgets;
 
     // allocate more funds to the budget
@@ -218,7 +202,7 @@ describe('BoostCore', () => {
       target: defaultOptions.account.address,
     });
 
-    const _boost = await client.createBoost({
+    const _boost = await core.createBoost({
       budget: budget,
       action: core.EventAction(
         makeMockEventActionPayload(
@@ -243,7 +227,7 @@ describe('BoostCore', () => {
         }),
       ],
     });
-    const boost = await client.createBoost({
+    const boost = await core.createBoost({
       budget: budget,
       action: core.EventAction(_boost.action.assertValidAddress(), false),
       validator: core.SignerValidator({
@@ -263,16 +247,12 @@ describe('BoostCore', () => {
         }),
       ],
     });
-    const onChainBoost = await client.readBoost(boost.id);
+    const onChainBoost = await core.readBoost(boost.id);
     expect(onChainBoost.action).toBe(_boost.action.assertValidAddress());
   });
 
   test('can reuse an existing validator', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
     const { budget, erc20 } = budgets;
 
     // allocate more erc20 funds to the budget from the owning accound
@@ -284,7 +264,7 @@ describe('BoostCore', () => {
       target: defaultOptions.account.address,
     });
 
-    const _boost = await client.createBoost({
+    const _boost = await core.createBoost({
       budget: budget,
       action: core.EventAction(
         makeMockEventActionPayload(
@@ -309,7 +289,7 @@ describe('BoostCore', () => {
         }),
       ],
     });
-    const boost = await client.createBoost({
+    const boost = await core.createBoost({
       budget: budget,
       action: core.EventAction(
         makeMockEventActionPayload(
@@ -334,16 +314,12 @@ describe('BoostCore', () => {
         }),
       ],
     });
-    const onChainBoost = await client.readBoost(boost.id);
+    const onChainBoost = await core.readBoost(boost.id);
     expect(onChainBoost.validator).toBe(_boost.validator.assertValidAddress());
   });
 
   test('can reuse an existing allowlist', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
     const { budget, erc20 } = budgets;
 
     // allocate more erc20 funds to the budget from the owning accound
@@ -355,7 +331,7 @@ describe('BoostCore', () => {
       target: defaultOptions.account.address,
     });
 
-    const _boost = await client.createBoost({
+    const _boost = await core.createBoost({
       budget: budget,
       action: core.EventAction(
         makeMockEventActionPayload(
@@ -380,7 +356,7 @@ describe('BoostCore', () => {
         }),
       ],
     });
-    const boost = await client.createBoost({
+    const boost = await core.createBoost({
       budget: budget,
       action: core.EventAction(
         makeMockEventActionPayload(
@@ -405,16 +381,12 @@ describe('BoostCore', () => {
         }),
       ],
     });
-    const onChainBoost = await client.readBoost(boost.id);
+    const onChainBoost = await core.readBoost(boost.id);
     expect(onChainBoost.allowList).toBe(_boost.allowList.assertValidAddress());
   });
 
   test('cannot reuse an existing incentive', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
     const { budget, erc20 } = budgets;
 
     // allocate more erc20 funds to the budget from the owning accound
@@ -432,7 +404,7 @@ describe('BoostCore', () => {
       limit: 100n,
       strategy: StrategyType.POOL,
     });
-    const _boost = await client.createBoost({
+    const _boost = await core.createBoost({
       budget: budget,
       action: core.EventAction(
         makeMockEventActionPayload(
@@ -451,7 +423,7 @@ describe('BoostCore', () => {
       incentives: [incentive],
     });
     try {
-      await client.createBoost({
+      await core.createBoost({
         budget: budget,
         action: core.EventAction(
           makeMockEventActionPayload(
@@ -476,10 +448,6 @@ describe('BoostCore', () => {
 
   test('can offer multiple incentives', async () => {
     const { registry, core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
     const { budget, erc20, points, erc1155 } = budgets;
     const allowList = await registry.initialize(
       'SharedAllowList',
@@ -520,7 +488,7 @@ describe('BoostCore', () => {
       limit: 10n,
     });
 
-    await client.createBoost({
+    await core.createBoost({
       protocolFee: 1n,
       referralFee: 2n,
       maxParticipants: 100n,
@@ -562,58 +530,38 @@ describe('BoostCore', () => {
 
   test('can get  the protocol fee', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
 
-    expect(await client.protocolFee()).toBe(1000n);
+    expect(await core.protocolFee()).toBe(1000n);
   });
 
   test('can get the protocol fee receiver', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
 
-    expect(await client.protocolFeeReceiver()).toBe(
+    expect(await core.protocolFeeReceiver()).toBe(
       defaultOptions.account.address,
     );
   });
 
   test('can set the protocol fee receiver', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
 
-    await client.setProcolFeeReceiver(zeroAddress);
+    await core.setProcolFeeReceiver(zeroAddress);
 
-    expect(await client.protocolFeeReceiver()).toBe(zeroAddress);
+    expect(await core.protocolFeeReceiver()).toBe(zeroAddress);
   });
 
   test('can get the claim fee', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
 
-    expect(await client.claimFee()).toBe(75000000000000n);
+    expect(await core.claimFee()).toBe(75000000000000n);
   });
 
   test('can set the claim fee', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
 
-    await client.setClaimFee(100n);
+    await core.setClaimFee(100n);
 
-    expect(await client.claimFee()).toBe(100n);
+    expect(await core.claimFee()).toBe(100n);
   });
 
   test('binds all actions, budgets, allowlists, incentives, and validators to reuse core options and account', () => {
@@ -713,13 +661,9 @@ describe('BoostCore', () => {
     const subscription = vi.fn();
 
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
-    client.subscribe(subscription, { pollingInterval: 100 });
+    core.subscribe(subscription, { pollingInterval: 100 });
     const { budget, erc20 } = budgets;
-    await client.createBoost({
+    await core.createBoost({
       protocolFee: 1n,
       referralFee: 2n,
       maxParticipants: 100n,
@@ -757,17 +701,13 @@ describe('BoostCore', () => {
 
   test('can set a passthrough auth scheme', async () => {
     const { core } = fixtures;
-    const client = new BoostCore({
-      ...defaultOptions,
-      address: core.assertValidAddress(),
-    });
 
-    const auth = client.PassthroughAuth();
+    const auth = core.PassthroughAuth();
     await auth.deploy();
-    await client.setCreateBoostAuth(auth);
-    expect((await client.createBoostAuth()).toLowerCase()).toBe(
+    await core.setCreateBoostAuth(auth);
+    expect((await core.createBoostAuth()).toLowerCase()).toBe(
       auth.assertValidAddress(),
     );
-    expect(await client.isAuthorized(zeroAddress)).toBe(true);
+    expect(await core.isAuthorized(zeroAddress)).toBe(true);
   });
 });

--- a/packages/sdk/src/BoostRegistry.ts
+++ b/packages/sdk/src/BoostRegistry.ts
@@ -9,7 +9,6 @@ import {
   writeBoostRegistryRegister,
 } from '@boostxyz/evm';
 import { bytecode } from '@boostxyz/evm/artifacts/contracts/BoostRegistry.sol/BoostRegistry.json';
-import { getAccount } from '@wagmi/core';
 import {
   type Address,
   type ContractEventName,
@@ -23,7 +22,6 @@ import {
   type GenericDeployableParams,
 } from './Deployable/Deployable';
 import type { DeployableTarget } from './Deployable/DeployableTarget';
-import { InvalidProtocolChainIdError, NoConnectedChainIdError } from './errors';
 import {
   type GenericLog,
   type HashAndSimulatedResult,
@@ -32,8 +30,6 @@ import {
   type WriteParams,
   assertValidAddressByChainId,
 } from './utils';
-
-export { boostRegistryAbi };
 
 /**
  * The address of the deployed `BoostRegistry` instance. In prerelease mode, this will be its sepolia address
@@ -167,6 +163,26 @@ export class BoostRegistry extends Deployable<
   typeof boostRegistryAbi
 > {
   /**
+   * A static property representing a map of stringified chain ID's to the address of the deployed implementation on chain
+   *
+   * @static
+   * @readonly
+   * @type {Record<string, Address>}
+   */
+  static readonly addresses: Record<number, Address> = BOOST_REGISTRY_ADDRESSES;
+
+  /**
+   * A getter that will return Boost registry's static addresses by numerical chain ID
+   *
+   * @public
+   * @readonly
+   * @type {Record<number, Address>}
+   */
+  public get addresses(): Record<number, Address> {
+    return (this.constructor as typeof BoostRegistry).addresses;
+  }
+
+  /**
    * Creates an instance of BoostRegistry.
    *
    * @see {@link BoostRegistryConfig}
@@ -182,7 +198,7 @@ export class BoostRegistry extends Deployable<
     } else if (isBoostRegistryDeployable(options)) {
       super({ account, config }, []);
     } else {
-      const address = assertValidAddressByChainId(
+      const { address } = assertValidAddressByChainId(
         config,
         BOOST_REGISTRY_ADDRESSES,
       );
@@ -235,7 +251,11 @@ export class BoostRegistry extends Deployable<
     const { request, result } = await simulateBoostRegistryRegister(
       this._config,
       {
-        address: this.assertValidAddress(),
+        ...assertValidAddressByChainId(
+          this._config,
+          this.addresses,
+          params?.chain?.id || params?.chainId,
+        ),
         args: [registryType, name, implementation],
         ...this.optionallyAttachAccount(),
         // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -329,7 +349,7 @@ export class BoostRegistry extends Deployable<
       config: this._config,
       account: this._account,
     });
-    const baseAddress = assertValidAddressByChainId(
+    const { address: baseAddress } = assertValidAddressByChainId(
       this._config,
       target.bases,
       params?.chain?.id || params?.chainId,
@@ -337,7 +357,11 @@ export class BoostRegistry extends Deployable<
     const { request, result } = await simulateBoostRegistryDeployClone(
       this._config,
       {
-        address: this.assertValidAddress(),
+        ...assertValidAddressByChainId(
+          this._config,
+          this.addresses,
+          params?.chain?.id || params?.chainId,
+        ),
         args: [target.registryType, baseAddress, displayName, payload.args[0]],
         ...this.optionallyAttachAccount(),
         // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -363,7 +387,11 @@ export class BoostRegistry extends Deployable<
     params?: ReadParams<typeof boostRegistryAbi, 'getBaseImplementation'>,
   ) {
     return await readBoostRegistryGetBaseImplementation(this._config, {
-      address: this.assertValidAddress(),
+      ...assertValidAddressByChainId(
+        this._config,
+        this.addresses,
+        params?.chainId,
+      ),
       args: [identifier],
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -385,7 +413,11 @@ export class BoostRegistry extends Deployable<
     params?: ReadParams<typeof boostRegistryAbi, 'getClone'>,
   ) {
     return await readBoostRegistryGetBaseImplementation(this._config, {
-      address: this.assertValidAddress(),
+      ...assertValidAddressByChainId(
+        this._config,
+        this.addresses,
+        params?.chainId,
+      ),
       args: [identifier],
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -407,7 +439,11 @@ export class BoostRegistry extends Deployable<
     params?: ReadParams<typeof boostRegistryAbi, 'getClones'>,
   ) {
     return await readBoostRegistryGetClones(this._config, {
-      address: this.assertValidAddress(),
+      ...assertValidAddressByChainId(
+        this._config,
+        this.addresses,
+        params?.chainId,
+      ),
       args: [deployer],
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -435,7 +471,11 @@ export class BoostRegistry extends Deployable<
     params?: ReadParams<typeof boostRegistryAbi, 'getCloneIdentifier'>,
   ) {
     return await readBoostRegistryGetCloneIdentifier(this._config, {
-      address: this.assertValidAddress(),
+      ...assertValidAddressByChainId(
+        this._config,
+        this.addresses,
+        params?.chainId,
+      ),
       args: [registryType, base, deployer, displayName],
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally
@@ -459,7 +499,11 @@ export class BoostRegistry extends Deployable<
     params?: ReadParams<typeof boostRegistryAbi, 'getIdentifier'>,
   ) {
     return await readBoostRegistryGetCloneIdentifier(this._config, {
-      address: this.assertValidAddress(),
+      ...assertValidAddressByChainId(
+        this._config,
+        this.addresses,
+        params?.chainId,
+      ),
       args: [registryType, displayName],
       ...this.optionallyAttachAccount(),
       // biome-ignore lint/suspicious/noExplicitAny: Accept any shape of valid wagmi/viem parameters, wagmi does the same thing internally

--- a/packages/sdk/src/Budgets/ManagedBudget.ts
+++ b/packages/sdk/src/Budgets/ManagedBudget.ts
@@ -33,6 +33,7 @@ import {
   parseAbiParameters,
   zeroAddress,
 } from 'viem';
+import { ManagedBudget as ManagedBudgetBases } from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -54,7 +55,6 @@ import {
   RegistryType,
   type WriteParams,
 } from '../utils';
-
 export { managedBudgetAbi };
 export type { ERC1155TransferPayload, FungibleTransferPayload };
 
@@ -189,10 +189,12 @@ export class ManagedBudget extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_MANAGED_BUDGET_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(ManagedBudgetBases as Record<number, Address>),
+    31337: import.meta.env.VITE_MANAGED_BUDGET_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Budgets/SimpleBudget.ts
+++ b/packages/sdk/src/Budgets/SimpleBudget.ts
@@ -151,10 +151,11 @@ export class SimpleBudget extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_SIMPLE_BUDGET_BASE;
+  public static override bases: Record<number, Address> = {
+    31337: import.meta.env.VITE_SIMPLE_BUDGET_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Budgets/VestingBudget.ts
+++ b/packages/sdk/src/Budgets/VestingBudget.ts
@@ -127,10 +127,11 @@ export class VestingBudget extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_VESTING_BUDGET_BASE;
+  public static override bases: Record<number, Address> = {
+    31337: import.meta.env.VITE_VESTING_BUDGET_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Incentives/AllowListIncentive.ts
+++ b/packages/sdk/src/Incentives/AllowListIncentive.ts
@@ -17,6 +17,7 @@ import {
   type Hex,
   encodeAbiParameters,
 } from 'viem';
+import { AllowListIncentive as AllowListIncentiveBases } from '../../dist/deployments.json';
 import { SimpleAllowList } from '../AllowLists/AllowList';
 import type {
   DeployableOptions,
@@ -92,10 +93,12 @@ export class AllowListIncentive extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_ALLOWLIST_INCENTIVE_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(AllowListIncentiveBases as Record<number, Address>),
+    31337: import.meta.env.VITE_ALLOWLIST_INCENTIVE_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Incentives/CGDAIncentive.ts
+++ b/packages/sdk/src/Incentives/CGDAIncentive.ts
@@ -21,6 +21,7 @@ import {
   type Hex,
   encodeAbiParameters,
 } from 'viem';
+import { CGDAIncentive as CGDAIncentiveBases } from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -144,10 +145,12 @@ export class CGDAIncentive extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_CGDA_INCENTIVE_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(CGDAIncentiveBases as Record<number, Address>),
+    31337: import.meta.env.VITE_CGDA_INCENTIVE_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Incentives/ERC1155Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC1155Incentive.ts
@@ -127,10 +127,11 @@ export class ERC1155Incentive extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_ERC1155_INCENTIVE_BASE;
+  public static override bases: Record<number, Address> = {
+    31337: import.meta.env.VITE_ERC1155_INCENTIVE_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Incentives/ERC20Incentive.ts
+++ b/packages/sdk/src/Incentives/ERC20Incentive.ts
@@ -24,6 +24,7 @@ import {
   type Hex,
   encodeAbiParameters,
 } from 'viem';
+import { ERC20Incentive as ERC20IncentiveBases } from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -110,10 +111,12 @@ export class ERC20Incentive extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_ERC20_INCENTIVE_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(ERC20IncentiveBases as Record<number, Address>),
+    31337: import.meta.env.VITE_ERC20_INCENTIVE_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
+++ b/packages/sdk/src/Incentives/ERC20VariableIncentive.ts
@@ -21,6 +21,7 @@ import {
   type Hex,
   encodeAbiParameters,
 } from 'viem';
+import { ERC20VariableIncentive as ERC20VariableIncentiveBases } from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -96,10 +97,12 @@ export class ERC20VariableIncentive extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_ERC20_VARIABLE_INCENTIVE_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(ERC20VariableIncentiveBases as Record<number, Address>),
+    31337: import.meta.env.VITE_ERC20_VARIABLE_INCENTIVE_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Incentives/PointsIncentive.ts
+++ b/packages/sdk/src/Incentives/PointsIncentive.ts
@@ -18,6 +18,7 @@ import {
   type Hex,
   encodeAbiParameters,
 } from 'viem';
+import { PointsIncentive as PointsIncentiveBases } from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -105,10 +106,12 @@ export class PointsIncentive extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_POINTS_INCENTIVE_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(PointsIncentiveBases as Record<number, Address>),
+    31337: import.meta.env.VITE_POINTS_INCENTIVE_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/Validators/SignerValidator.ts
+++ b/packages/sdk/src/Validators/SignerValidator.ts
@@ -18,6 +18,7 @@ import {
   encodeAbiParameters,
 } from 'viem';
 import { signTypedData } from 'viem/accounts';
+import { SignerValidator as SignerValidatorBases } from '../../dist/deployments.json';
 import type {
   DeployableOptions,
   GenericDeployableParams,
@@ -306,10 +307,12 @@ export class SignerValidator extends DeployableTarget<
    *
    * @public
    * @static
-   * @type {Address}
+   * @type {Record<number, Address>}
    */
-  public static override base: Address = import.meta.env
-    .VITE_SIGNER_VALIDATOR_BASE;
+  public static override bases: Record<number, Address> = {
+    ...(SignerValidatorBases as Record<number, Address>),
+    31337: import.meta.env.VITE_SIGNER_VALIDATOR_BASE,
+  };
   /**
    * @inheritdoc
    *

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -87,7 +87,7 @@ export class DeployableAlreadyDeployedError extends Error {
    */
   constructor(address: string) {
     super(
-      `Attempted to deploy a contract that already has an address configured`,
+      'Attempted to deploy a contract that already has an address configured',
     );
     this.address = address;
   }
@@ -678,5 +678,21 @@ export class UnrecognizedFilterTypeError extends FieldActionValidationError {
     metadata: EventActionValidationMeta | FunctionActionValidationMeta,
   ) {
     super('Invalid FilterType provided', metadata);
+  }
+}
+
+export class NoConnectedChainIdError extends Error {
+  constructor() {
+    super(
+      'Provided Wagmi configuration does not define `chainId` property with which to target protocol contracts',
+    );
+  }
+}
+
+export class InvalidProtocolChainIdError extends Error {
+  constructor(chainId: number, validChainIds: number[]) {
+    super(
+      `Provided Wagmi configuration supplied a "chainId" where protocol is not deployed, provided: ${chainId}, but valid chains are: ${validChainIds}`,
+    );
   }
 }

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -205,21 +205,20 @@ export async function awaitResult<Result = unknown>(
 }
 
 /**
- * Given a wagmi config and a map of chain id's to addresses, determine an address that maps to the currently connected chain id, or throw a typed error.
+ * Given a wagmi config and a map of chain id's to addresses, determine an address/chainId combo that maps to the currently connected chain id, or throw a typed error.
  *
  * @export
  * @param {Config} config
  * @param {Record<string, Address>} addressByChainId
  * @param {number} desiredChainId
- * @returns {Address}
- * @throws {@link NoConnectedChainIdError}
+ * @returns {{ chainId: number, address: Address }}
  * @throws {@link InvalidProtocolChainIdError}
  */
 export function assertValidAddressByChainId(
   config: Config,
   addressByChainId: Record<number, Address>,
   desiredChainId?: number,
-): Address {
+): { chainId: number; address: Address } {
   let chainId: number | undefined = undefined;
   const wagmiAccount = getAccount(config);
   // if manually providing a chain id for some contract operation, try to use it
@@ -244,5 +243,5 @@ export function assertValidAddressByChainId(
       Object.keys(addressByChainId).map(Number),
     );
   // biome-ignore lint/style/noNonNullAssertion: this type should be narrowed by the above statement but isn't?
-  return addressByChainId[chainId]!;
+  return { chainId, address: addressByChainId[chainId]! };
 }

--- a/packages/sdk/test/delegate-action.test.ts
+++ b/packages/sdk/test/delegate-action.test.ts
@@ -68,11 +68,6 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
       const { budget, erc20 } = budgets;
 
       const { core } = fixtures;
-
-      const client = new BoostCore({
-        ...defaultOptions,
-        address: core.assertValidAddress(),
-      });
       const owner = defaultOptions.account.address;
       // This is a workaround to this known issue: https://github.com/NomicFoundation/hardhat/issues/5511
       await mine();
@@ -106,7 +101,7 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
       // Initialize EventAction with the custom payload
       const eventAction = core.EventAction(eventActionPayload);
       // Create the boost using the custom EventAction
-      await client.createBoost({
+      await core.createBoost({
         protocolFee: 250n,
         referralFee: 250n,
         maxParticipants: 100n,
@@ -131,8 +126,8 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
       });
 
       // Make sure the boost was created as expected
-      expect(await client.getBoostCount()).toBe(1n);
-      const boost = await client.getBoost(0n);
+      expect(await core.getBoostCount()).toBe(1n);
+      const boost = await core.getBoost(0n);
       const action = boost.action;
       expect(action).toBeDefined();
 

--- a/packages/sdk/test/ens-register.test.ts
+++ b/packages/sdk/test/ens-register.test.ts
@@ -85,11 +85,6 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
       const { budget, erc20 } = budgets;
 
       const { core, bases } = fixtures;
-
-      const client = new BoostCore({
-        ...defaultOptions,
-        address: core.assertValidAddress(),
-      });
       const owner = defaultOptions.account.address;
       // This is a workaround to this known issue: https://github.com/NomicFoundation/hardhat/issues/5511
       await mine();
@@ -126,7 +121,7 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
         eventActionPayload,
       );
       // Create the boost using the custom EventAction
-      await client.createBoost({
+      await core.createBoost({
         protocolFee: 250n,
         referralFee: 250n,
         maxParticipants: 100n,
@@ -151,8 +146,8 @@ describe.skipIf(!process.env.VITE_ALCHEMY_API_KEY)(
       });
 
       // Make sure the boost was created as expected
-      expect(await client.getBoostCount()).toBe(1n);
-      const boost = await client.getBoost(0n);
+      expect(await core.getBoostCount()).toBe(1n);
+      const boost = await core.getBoost(0n);
       const action = boost.action;
       expect(action).toBeDefined();
 

--- a/packages/sdk/test/helpers.ts
+++ b/packages/sdk/test/helpers.ts
@@ -287,59 +287,97 @@ export async function deployFixtures(
     }),
   );
 
+  const chainId = 1337;
+
   const bases = {
     ContractAction: class TContractAction extends ContractAction {
-      public static override base = contractActionBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: contractActionBase,
+      };
     },
     EventAction: class TEventAction extends EventAction {
-      public static override base = eventActionBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: eventActionBase,
+      };
     },
     ERC721MintAction: class TERC721MintAction extends ERC721MintAction {
-      public static override base = erc721MintActionBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: erc721MintActionBase,
+      };
     },
     SimpleAllowList: class TSimpleAllowList extends SimpleAllowList {
-      public static override base = simpleAllowListBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: simpleAllowListBase,
+      };
     },
     SimpleDenyList: class TSimpleDenyList extends SimpleDenyList {
-      public static override base = simpleDenyListBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: simpleDenyListBase,
+      };
     },
     OpenAllowList: class TOpenAllowList extends OpenAllowList {
-      public static override base = simpleDenyListBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: simpleDenyListBase,
+      };
     },
     SimpleBudget: class TSimpleBudget extends SimpleBudget {
-      public static override base = simpleBudgetBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: simpleBudgetBase,
+      };
     },
     ManagedBudget: class TManagedBudget extends ManagedBudget {
-      public static override base = managedBudgetBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: managedBudgetBase,
+      };
     },
     VestingBudget: class TVestingBudget extends VestingBudget {
-      public static override base = vestingBudgetBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: vestingBudgetBase,
+      };
     },
     AllowListIncentive: class TAllowListIncentive extends AllowListIncentive {
-      public static override base = allowListIncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: allowListIncentiveBase,
+      };
     },
     CGDAIncentive: class TCGDAIncentive extends CGDAIncentive {
-      public static override base = cgdaIncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: cgdaIncentiveBase,
+      };
     },
     ERC20Incentive: class TERC20Incentive extends ERC20Incentive {
-      public static override base = erc20IncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: erc20IncentiveBase,
+      };
     },
     ERC20VariableIncentive: class TERC20VariableIncentive extends ERC20VariableIncentive {
-      public static override base = erc20VariableIncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: erc20VariableIncentiveBase,
+      };
     },
     ERC1155Incentive: class TERC1155Incentive extends ERC1155Incentive {
-      public static override base = erc1155IncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: erc1155IncentiveBase,
+      };
     },
     PointsIncentive: class TPointsIncentive extends PointsIncentive {
-      public static override base = pointsIncentiveBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: pointsIncentiveBase,
+      };
     },
     SignerValidator: class TSignerValidator extends SignerValidator {
-      public static override base = signerValidatorBase;
+      public static override bases: Record<number, Address> = {
+        [chainId]: signerValidatorBase,
+      };
     },
   };
 
   for (const [name, deployable] of Object.entries(bases)) {
-    await registry.register(deployable.registryType, name, deployable.base);
+    await registry.register(
+      deployable.registryType,
+      name,
+      deployable.bases[chainId]!,
+    );
   }
 
   class TBoostCore extends BoostCore {
@@ -393,10 +431,13 @@ export async function deployFixtures(
         isBase,
       );
     }
-    override OpenAllowList(isBase?: boolean) {
+    override OpenAllowList(
+      options: DeployablePayloadOrAddress<undefined>,
+      isBase?: boolean,
+    ) {
       return new bases.OpenAllowList(
         { config: this._config, account: this._account },
-        undefined,
+        options,
         isBase,
       );
     }
@@ -787,43 +828,41 @@ export function fundBudget(
   points?: MockPoints,
 ) {
   return async function fundBudget() {
-    {
-      if (!budget)
-        budget = await loadFixture(freshManagedBudget(options, fixtures)); // await loadFixture(freshBudget(options, fixtures));
-      if (!erc20) erc20 = await loadFixture(fundErc20(options));
-      if (!erc1155) erc1155 = await loadFixture(fundErc1155(options));
-      if (!points) points = await loadFixture(fundPoints(options));
+    if (!budget)
+      budget = await loadFixture(freshManagedBudget(options, fixtures)); // await loadFixture(freshBudget(options, fixtures));
+    if (!erc20) erc20 = await loadFixture(fundErc20(options));
+    if (!erc1155) erc1155 = await loadFixture(fundErc1155(options));
+    if (!points) points = await loadFixture(fundPoints(options));
 
-      await budget.allocate(
-        {
-          amount: parseEther('1.0'),
-          asset: zeroAddress,
-          target: options.account.address,
-        },
-        { value: parseEther('1.0') },
-      );
-
-      await erc20.approve(budget.assertValidAddress(), parseEther('100'));
-      await budget.allocate({
-        amount: parseEther('100'),
-        asset: erc20.assertValidAddress(),
+    await budget.allocate(
+      {
+        amount: parseEther('1.0'),
+        asset: zeroAddress,
         target: options.account.address,
-      });
+      },
+      { value: parseEther('1.0') },
+    );
 
-      await writeMockErc1155SetApprovalForAll(options.config, {
-        args: [budget.assertValidAddress(), true],
-        address: erc1155.assertValidAddress(),
-        account: options.account,
-      });
-      await budget.allocate({
-        tokenId: 1n,
-        amount: 100n,
-        asset: erc1155.assertValidAddress(),
-        target: options.account.address,
-      });
+    await erc20.approve(budget.assertValidAddress(), parseEther('100'));
+    await budget.allocate({
+      amount: parseEther('100'),
+      asset: erc20.assertValidAddress(),
+      target: options.account.address,
+    });
 
-      return { budget, erc20, erc1155, points } as BudgetFixtures;
-    }
+    await writeMockErc1155SetApprovalForAll(options.config, {
+      args: [budget.assertValidAddress(), true],
+      address: erc1155.assertValidAddress(),
+      account: options.account,
+    });
+    await budget.allocate({
+      tokenId: 1n,
+      amount: 100n,
+      asset: erc1155.assertValidAddress(),
+      target: options.account.address,
+    });
+
+    return { budget, erc20, erc1155, points } as BudgetFixtures;
   };
 }
 
@@ -836,45 +875,43 @@ export function fundManagedBudget(
   points?: MockPoints,
 ) {
   return async function fundBudget() {
-    {
-      if (!budget)
-        budget = await loadFixture(freshManagedBudget(options, fixtures));
-      if (!erc20) erc20 = await loadFixture(fundErc20(options));
-      if (!erc1155) erc1155 = await loadFixture(fundErc1155(options));
-      if (!points) points = await loadFixture(fundPoints(options));
+    if (!budget)
+      budget = await loadFixture(freshManagedBudget(options, fixtures));
+    if (!erc20) erc20 = await loadFixture(fundErc20(options));
+    if (!erc1155) erc1155 = await loadFixture(fundErc1155(options));
+    if (!points) points = await loadFixture(fundPoints(options));
 
-      await budget.allocate(
-        {
-          amount: parseEther('1.0'),
-          asset: zeroAddress,
-          target: options.account.address,
-        },
-        { value: parseEther('1.0') },
-      );
-
-      await erc20.approve(budget.assertValidAddress(), parseEther('100'));
-      await budget.allocate({
-        amount: parseEther('100'),
-        asset: erc20.assertValidAddress(),
+    await budget.allocate(
+      {
+        amount: parseEther('1.0'),
+        asset: zeroAddress,
         target: options.account.address,
-      });
+      },
+      { value: parseEther('1.0') },
+    );
 
-      await writeMockErc1155SetApprovalForAll(options.config, {
-        args: [budget.assertValidAddress(), true],
-        address: erc1155.assertValidAddress(),
-        account: options.account,
-      });
-      await budget.allocate({
-        tokenId: 1n,
-        amount: 100n,
-        asset: erc1155.assertValidAddress(),
-        target: options.account.address,
-      });
+    await erc20.approve(budget.assertValidAddress(), parseEther('100'));
+    await budget.allocate({
+      amount: parseEther('100'),
+      asset: erc20.assertValidAddress(),
+      target: options.account.address,
+    });
 
-      return { budget, erc20, erc1155, points } as BudgetFixtures & {
-        budget: ManagedBudget;
-      };
-    }
+    await writeMockErc1155SetApprovalForAll(options.config, {
+      args: [budget.assertValidAddress(), true],
+      address: erc1155.assertValidAddress(),
+      account: options.account,
+    });
+    await budget.allocate({
+      tokenId: 1n,
+      amount: 100n,
+      asset: erc1155.assertValidAddress(),
+      target: options.account.address,
+    });
+
+    return { budget, erc20, erc1155, points } as BudgetFixtures & {
+      budget: ManagedBudget;
+    };
   };
 }
 
@@ -887,31 +924,29 @@ export function fundVestingBudget(
   points?: MockPoints,
 ) {
   return async function fundVestingBudget() {
-    {
-      if (!budget)
-        budget = await loadFixture(freshManagedBudget(options, fixtures));
-      if (!erc20) erc20 = await loadFixture(fundErc20(options));
-      if (!erc1155) erc1155 = await loadFixture(fundErc1155(options));
-      if (!points) points = await loadFixture(fundPoints(options));
+    if (!budget)
+      budget = await loadFixture(freshManagedBudget(options, fixtures));
+    if (!erc20) erc20 = await loadFixture(fundErc20(options));
+    if (!erc1155) erc1155 = await loadFixture(fundErc1155(options));
+    if (!points) points = await loadFixture(fundPoints(options));
 
-      await budget.allocate(
-        {
-          amount: parseEther('1.0'),
-          asset: zeroAddress,
-          target: options.account.address,
-        },
-        { value: parseEther('1.0') },
-      );
-
-      await erc20.approve(budget.assertValidAddress(), parseEther('100'));
-      await budget.allocate({
-        amount: parseEther('100'),
-        asset: erc20.assertValidAddress(),
+    await budget.allocate(
+      {
+        amount: parseEther('1.0'),
+        asset: zeroAddress,
         target: options.account.address,
-      });
+      },
+      { value: parseEther('1.0') },
+    );
 
-      return { budget, erc20, erc1155, points } as BudgetFixtures;
-    }
+    await erc20.approve(budget.assertValidAddress(), parseEther('100'));
+    await budget.allocate({
+      amount: parseEther('100'),
+      asset: erc20.assertValidAddress(),
+      target: options.account.address,
+    });
+
+    return { budget, erc20, erc1155, points } as BudgetFixtures;
   };
 }
 

--- a/packages/sdk/vite-env.d.ts
+++ b/packages/sdk/vite-env.d.ts
@@ -2,6 +2,11 @@
 
 import type { Address } from 'viem';
 
+declare global {
+  // If process.env.DEFAULT_CHAIN_ID exists, use it otherwise default to sepolia
+  const __DEFAULT_CHAIN_ID__: string;
+}
+
 interface ImportMetaEnv {
   readonly VITE_BOOST_REGISTRY_ADDRESS: Address;
   readonly VITE_BOOST_CORE_ADDRESS: Address;

--- a/packages/sdk/vite.config.js
+++ b/packages/sdk/vite.config.js
@@ -1,6 +1,38 @@
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import packageJson from './package.json';
 
+// get all deployments checked into `packages/evm/deploys`
+const deployments = (
+  await readdirSync(resolve(__dirname, '../evm/deploys'))
+).filter((file) => Number(file.split('.').at(0)) > 0);
+
+// Record<BaseName, Record<chainId, Address>>
+const baseContractChainIdAddresses = {};
+// traverse deployments, build data structure to define in build
+for (const chainDeployment of deployments) {
+  const baseAddresses = JSON.parse(
+    (await readFileSync(`../evm/deploys/${chainDeployment}`)).toString(),
+  );
+  const chainId = Number(chainDeployment.split('.').at(0));
+  for (const [baseName, address] of Object.entries(baseAddresses)) {
+    if (!baseContractChainIdAddresses[baseName])
+      baseContractChainIdAddresses[baseName] = {};
+    baseContractChainIdAddresses[baseName][chainId] = address;
+  }
+}
+
+// Write the file to avoid stringifying / parsing injected string at runtime
+const baseContractChainIdAddressesArtifact = JSON.stringify(
+  baseContractChainIdAddresses,
+  null,
+  2,
+);
+writeFileSync(
+  resolve(__dirname, './dist/deployments.json'),
+  baseContractChainIdAddressesArtifact,
+);
+// parse package.json exports and map them to their associated src/**/*.ts entrypoint folders
 const moduleDirectories = Object.keys(packageJson.exports).reduce(
   (acc, path) => {
     if (path === '.') return acc;
@@ -17,15 +49,19 @@ const moduleDirectories = Object.keys(packageJson.exports).reduce(
 
 /** @type {import('vite').UserConfig} */
 export default {
+  define: {
+    __DEFAULT_CHAIN_ID__: process.env.DEFAULT_CHAIN_ID || '11155111',
+  },
   build: {
+    emptyOutDir: false,
     sourcemap: true,
     rollupOptions: {
       external: [/^viem/, /^@wagmi(?!.*\/codegen)/],
     },
     lib: {
-      entry: Object.keys(packageJson.exports).map((mod) =>
-        resolve('./src', `${mod === '.' ? 'index' : mod}.ts`),
-      ),
+      entry: Object.keys(packageJson.exports)
+        .filter((exportName) => !exportName.endsWith('.json'))
+        .map((mod) => resolve('./src', `${mod === '.' ? 'index' : mod}.ts`)),
       name: 'BoostSDK',
       fileName: (module, name) => {
         if (name === 'index')

--- a/packages/sdk/vite.config.js
+++ b/packages/sdk/vite.config.js
@@ -50,7 +50,7 @@ const moduleDirectories = Object.keys(packageJson.exports).reduce(
 /** @type {import('vite').UserConfig} */
 export default {
   define: {
-    __DEFAULT_CHAIN_ID__: process.env.DEFAULT_CHAIN_ID || '11155111',
+    __DEFAULT_CHAIN_ID__: Number(process.env.DEFAULT_CHAIN_ID) || 11155111,
   },
   build: {
     emptyOutDir: false,

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   define: {
-    __DEFAULT_CHAIN_ID__: '1337',
+    __DEFAULT_CHAIN_ID__: 31337,
   },
   test: {
     fileParallelism: false,

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -2,7 +2,9 @@ import { loadEnv } from 'vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  define: {},
+  define: {
+    __DEFAULT_CHAIN_ID__: '1337',
+  },
   test: {
     fileParallelism: false,
     env: loadEnv('', process.cwd(), ''),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2526,13 +2526,13 @@ packages:
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
 
-  '@noble/hashes@1.3.3':
-    resolution: {integrity: sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==}
-    engines: {node: '>= 16'}
-
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
+
+  '@noble/hashes@1.5.0':
+    resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/secp256k1@1.7.1':
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
@@ -3151,6 +3151,9 @@ packages:
 
   '@scure/base@1.1.6':
     resolution: {integrity: sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==}
+
+  '@scure/base@1.1.9':
+    resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
 
   '@scure/bip32@1.1.5':
     resolution: {integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==}
@@ -8160,7 +8163,7 @@ snapshots:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8220,7 +8223,7 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -10999,7 +11002,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.0.0
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.5.0
       '@scure/base': 1.1.6
       '@types/debug': 4.1.12
       debug: 4.3.4(supports-color@8.1.1)
@@ -11095,9 +11098,9 @@ snapshots:
 
   '@noble/hashes@1.3.2': {}
 
-  '@noble/hashes@1.3.3': {}
-
   '@noble/hashes@1.4.0': {}
+
+  '@noble/hashes@1.5.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -11194,7 +11197,7 @@ snapshots:
 
   '@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.13.1(bufferutil@4.0.8))(hardhat@2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3))':
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       ethers: 6.13.1(bufferutil@4.0.8)
       hardhat: 2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)
       lodash.isequal: 4.5.0
@@ -11335,7 +11338,7 @@ snapshots:
       '@ethersproject/address': 5.7.0
       cbor: 8.1.0
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       hardhat: 2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)
       lodash.clonedeep: 4.5.0
       semver: 6.3.1
@@ -11350,7 +11353,7 @@ snapshots:
       '@ethersproject/address': 5.7.0
       cbor: 8.1.0
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       hardhat: 2.22.9(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.12.11)(typescript@5.3.3))(typescript@5.3.3)
       lodash.clonedeep: 4.5.0
       semver: 6.3.1
@@ -11970,6 +11973,8 @@ snapshots:
 
   '@scure/base@1.1.6': {}
 
+  '@scure/base@1.1.9': {}
+
   '@scure/bip32@1.1.5':
     dependencies:
       '@noble/hashes': 1.2.0
@@ -11979,14 +11984,14 @@ snapshots:
   '@scure/bip32@1.3.2':
     dependencies:
       '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.3
-      '@scure/base': 1.1.6
+      '@noble/hashes': 1.3.2
+      '@scure/base': 1.1.9
 
   '@scure/bip32@1.4.0':
     dependencies:
       '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.6
+      '@scure/base': 1.1.9
 
   '@scure/bip39@1.1.1':
     dependencies:
@@ -11995,13 +12000,13 @@ snapshots:
 
   '@scure/bip39@1.2.1':
     dependencies:
-      '@noble/hashes': 1.3.3
-      '@scure/base': 1.1.6
+      '@noble/hashes': 1.3.2
+      '@scure/base': 1.1.9
 
   '@scure/bip39@1.3.0':
     dependencies:
       '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.6
+      '@scure/base': 1.1.9
 
   '@sentry/core@5.30.0':
     dependencies:
@@ -14011,7 +14016,7 @@ snapshots:
 
   ethereum-bloom-filters@1.1.0:
     dependencies:
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.5.0
 
   ethereum-cryptography@0.1.3:
     dependencies:
@@ -17272,7 +17277,7 @@ snapshots:
   typechain@8.3.2(typescript@5.3.3):
     dependencies:
       '@types/prettier': 2.7.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7
       fs-extra: 7.0.1
       glob: 7.1.7
       js-sha3: 0.8.0


### PR DESCRIPTION
### Description
Please describe your pull request

- this should remove our dependence on `VITE_BASE_ADDRESS` env injection, and allow developers to switch between test/live chains without swapping package versions
- turn `Class.base: Address` into `Class.bases: Record<number, Address>`
- add `__DEFAULT_CHAIN_ID__` global variable provided at build time that can be set via `process.env.DEFAULT_CHAIN_ID` but is currently defaulting to sepolia
- add logic to sdk vite to build a `Record<ContractName, Record<number, Address>>` json file included in the bundle

💔 Thank you!
