### PR TITLE
[ADHOC] fix(signatures): pad function selectors to 32 bytes

### DIFF
--- a/.changeset/red-stingrays-greet.md
+++ b/.changeset/red-stingrays-greet.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/signatures": minor
+---
+
+pad function selectors to 32 bytes in signatures package

--- a/packages/sdk/src/Actions/EventAction.test.ts
+++ b/packages/sdk/src/Actions/EventAction.test.ts
@@ -1,6 +1,6 @@
-import { selectors as eventSelectors } from '@boostxyz/signatures/events';
-import { selectors as funcSelectors } from '@boostxyz/signatures/functions';
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { selectors as eventSelectors } from "@boostxyz/signatures/events";
+import { selectors as funcSelectors } from "@boostxyz/signatures/functions";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import {
   type AbiEvent,
   type Address,
@@ -11,11 +11,11 @@ import {
   pad,
   parseEther,
   toHex,
-} from 'viem';
-import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
-import type { MockERC20 } from '../../test/MockERC20';
-import type { MockERC721 } from '../../test/MockERC721';
-import { accounts } from '../../test/accounts';
+} from "viem";
+import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+import type { MockERC20 } from "../../test/MockERC20";
+import type { MockERC721 } from "../../test/MockERC721";
+import { accounts } from "../../test/accounts";
 import {
   type Fixtures,
   type StringEmitterFixtures,
@@ -24,7 +24,7 @@ import {
   fundErc20,
   deployStringEmitterMock,
   fundErc721,
-} from '../../test/helpers';
+} from "../../test/helpers";
 import {
   EventAction,
   type EventLogs,
@@ -32,7 +32,7 @@ import {
   FilterType,
   PrimitiveType,
   SignatureType,
-} from './EventAction';
+} from "./EventAction";
 
 let fixtures: Fixtures,
   erc721: MockERC721,
@@ -51,7 +51,7 @@ function basicErc721TransferAction(
     actionClaimant: {
       signatureType: SignatureType.EVENT,
       signature: eventSelectors[
-        'Transfer(address indexed,address indexed,uint256 indexed)'
+        "Transfer(address indexed,address indexed,uint256 indexed)"
       ] as Hex,
       fieldIndex: 1,
       targetContract: erc721.assertValidAddress(),
@@ -60,7 +60,7 @@ function basicErc721TransferAction(
     actionSteps: [
       {
         signature: eventSelectors[
-          'Transfer(address indexed,address indexed,uint256 indexed)'
+          "Transfer(address indexed,address indexed,uint256 indexed)"
         ] as Hex,
         signatureType: SignatureType.EVENT,
         targetContract: erc721.assertValidAddress(),
@@ -88,17 +88,18 @@ function cloneEventAction(fixtures: Fixtures, erc721: MockERC721) {
 function basicErc721MintFuncAction(
   erc721: MockERC721,
 ): EventActionPayloadSimple {
+  console.log(funcSelectors["mint(address)"] as Hex);
   return {
     actionClaimant: {
       signatureType: SignatureType.FUNC,
-      signature: pad(funcSelectors['mint(address)'] as Hex),
+      signature: funcSelectors["mint(address)"] as Hex,
       fieldIndex: 0,
       targetContract: erc721.assertValidAddress(),
       chainid: defaultOptions.config.chains[0].id,
     },
     actionSteps: [
       {
-        signature: pad(funcSelectors['mint(address)'] as Hex),
+        signature: funcSelectors["mint(address)"] as Hex,
         signatureType: SignatureType.FUNC,
         actionType: 0,
         targetContract: erc721.assertValidAddress(),
@@ -118,16 +119,14 @@ function basicErc20MintFuncAction(erc20: MockERC20): EventActionPayloadSimple {
   return {
     actionClaimant: {
       signatureType: SignatureType.FUNC,
-      signature: pad(funcSelectors['mint(address to, uint256 amount)'] as Hex),
+      signature: funcSelectors["mint(address to, uint256 amount)"] as Hex,
       fieldIndex: 0,
       targetContract: erc20.assertValidAddress(),
       chainid: defaultOptions.config.chains[0].id,
     },
     actionSteps: [
       {
-        signature: pad(
-          funcSelectors['mint(address to, uint256 amount)'] as Hex,
-        ),
+        signature: funcSelectors["mint(address to, uint256 amount)"] as Hex,
         signatureType: SignatureType.FUNC,
         actionType: 0,
         targetContract: erc20.assertValidAddress(),
@@ -153,7 +152,7 @@ function indexedStringErc721TransferAction(
     actionClaimant: {
       signatureType: SignatureType.EVENT,
       signature: eventSelectors[
-        'Transfer(address indexed,address indexed,uint256 indexed)'
+        "Transfer(address indexed,address indexed,uint256 indexed)"
       ] as Hex,
       fieldIndex: 1,
       targetContract: erc721.assertValidAddress(),
@@ -162,7 +161,7 @@ function indexedStringErc721TransferAction(
     actionSteps: [
       {
         signature: eventSelectors[
-          'InfoIndexed(address indexed,string indexed)'
+          "InfoIndexed(address indexed,string indexed)"
         ] as Hex,
         signatureType: SignatureType.EVENT,
         actionType: 0,
@@ -189,7 +188,7 @@ function stringErc721TransferAction(
     actionClaimant: {
       signatureType: SignatureType.EVENT,
       signature: eventSelectors[
-        'Transfer(address indexed,address indexed,uint256 indexed)'
+        "Transfer(address indexed,address indexed,uint256 indexed)"
       ] as Hex,
       fieldIndex: 1,
       targetContract: erc721.assertValidAddress(),
@@ -197,7 +196,7 @@ function stringErc721TransferAction(
     },
     actionSteps: [
       {
-        signature: eventSelectors['Info(address,string)'] as Hex,
+        signature: eventSelectors["Info(address,string)"] as Hex,
         signatureType: SignatureType.EVENT,
         actionType: 0,
         targetContract: stringEmitterAddress,
@@ -249,13 +248,13 @@ function cloneStringEventAction(
   };
 }
 
-describe('EventAction Event Selector', () => {
+describe("EventAction Event Selector", () => {
   beforeEach(async () => {
     erc721 = await loadFixture(fundErc721(defaultOptions));
   });
 
-  describe('basic transfer event', () => {
-    test('can successfully be deployed', async () => {
+  describe("basic transfer event", () => {
+    test("can successfully be deployed", async () => {
       const action = new EventAction(
         defaultOptions,
         basicErc721TransferAction(erc721),
@@ -264,17 +263,17 @@ describe('EventAction Event Selector', () => {
       expect(isAddress(action.assertValidAddress())).toBe(true);
     });
 
-    test('can get an action step', async () => {
+    test("can get an action step", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const step = await action.getActionStep(0);
       if (!step)
-        throw new Error('there should be an action step at this index');
+        throw new Error("there should be an action step at this index");
       step.targetContract = step.targetContract.toUpperCase() as Hex;
       step.actionParameter.filterData =
         step.actionParameter.filterData.toUpperCase() as Hex;
       expect(step).toMatchObject({
         signature: eventSelectors[
-          'Transfer(address indexed,address indexed,uint256 indexed)'
+          "Transfer(address indexed,address indexed,uint256 indexed)"
         ] as Hex,
         signatureType: SignatureType.EVENT,
         actionType: 0,
@@ -288,7 +287,7 @@ describe('EventAction Event Selector', () => {
       });
     });
 
-    test('can get all action steps', async () => {
+    test("can get all action steps", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const steps = await action.getActionSteps();
       expect(steps.length).toBe(1);
@@ -298,7 +297,7 @@ describe('EventAction Event Selector', () => {
         step.actionParameter.filterData.toUpperCase() as Hex;
       expect(step).toMatchObject({
         signature: eventSelectors[
-          'Transfer(address indexed,address indexed,uint256 indexed)'
+          "Transfer(address indexed,address indexed,uint256 indexed)"
         ] as Hex,
         signatureType: SignatureType.EVENT,
         actionType: 0,
@@ -312,26 +311,26 @@ describe('EventAction Event Selector', () => {
       });
     });
 
-    test('can get the total number of action steps', async () => {
+    test("can get the total number of action steps", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const count = await action.getActionStepsCount();
       expect(count).toBe(1);
     });
 
-    test('can get the action claimant', async () => {
+    test("can get the action claimant", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const claimant = await action.getActionClaimant();
       claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
       expect(claimant).toMatchObject({
         signatureType: SignatureType.EVENT,
         signature: eventSelectors[
-          'Transfer(address indexed,address indexed,uint256 indexed)'
+          "Transfer(address indexed,address indexed,uint256 indexed)"
         ] as Hex,
         fieldIndex: 1,
       });
     });
 
-    test('can get all action steps', async () => {
+    test("can get all action steps", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const steps = await action.getActionSteps();
       expect(steps.length).toBe(1);
@@ -341,7 +340,7 @@ describe('EventAction Event Selector', () => {
         step.actionParameter.filterData.toUpperCase() as Hex;
       expect(step).toMatchObject({
         signature: eventSelectors[
-          'Transfer(address indexed,address indexed,uint256 indexed)'
+          "Transfer(address indexed,address indexed,uint256 indexed)"
         ] as Hex,
         signatureType: SignatureType.EVENT,
         actionType: 0,
@@ -355,32 +354,32 @@ describe('EventAction Event Selector', () => {
       });
     });
 
-    test('can get the total number of action steps', async () => {
+    test("can get the total number of action steps", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const count = await action.getActionStepsCount();
       expect(count).toBe(1);
     });
 
-    test('can get the action claimant', async () => {
+    test("can get the action claimant", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const claimant = await action.getActionClaimant();
       claimant.targetContract = claimant.targetContract.toUpperCase() as Hex;
       expect(claimant).toMatchObject({
         signatureType: SignatureType.EVENT,
         signature: eventSelectors[
-          'Transfer(address indexed,address indexed,uint256 indexed)'
+          "Transfer(address indexed,address indexed,uint256 indexed)"
         ] as Hex,
         fieldIndex: 1,
         targetContract: erc721.assertValidAddress().toUpperCase(),
       });
     });
 
-    test('with no logs, does not validate', async () => {
+    test("with no logs, does not validate", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       expect(await action.validateActionSteps()).toBe(false);
     });
 
-    test('with a correct log, validates', async () => {
+    test("with a correct log, validates", async () => {
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
       const recipient = accounts[1].account;
       await erc721.approve(recipient, 1n);
@@ -388,100 +387,98 @@ describe('EventAction Event Selector', () => {
       expect(await action.validateActionSteps()).toBe(true);
     });
 
-    test('can supply your own logs to validate against', async () => {
+    test("can supply your own logs to validate against", async () => {
       const logs: EventLogs = [
         {
-          eventName: 'Transfer',
+          eventName: "Transfer",
           args: [
-            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-            '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+            "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
             1n,
           ],
           address: erc721.assertValidAddress(),
           blockHash:
-            '0xbf602f988260519805d032be46d6ff97fbefbee6924b21097074d6d0bc34eced',
+            "0xbf602f988260519805d032be46d6ff97fbefbee6924b21097074d6d0bc34eced",
           blockNumber: 1203n,
-          data: '0x',
+          data: "0x",
           logIndex: 0,
           removed: false,
           topics: [
-            '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-            '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
-            '0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8',
-            '0x0000000000000000000000000000000000000000000000000000000000000001',
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            "0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
           ],
           transactionHash:
-            '0xff0e6ab0c4961ec14b7b40afec83ed7d7a77582683512a262e641d21f82efea5',
+            "0xff0e6ab0c4961ec14b7b40afec83ed7d7a77582683512a262e641d21f82efea5",
           transactionIndex: 0,
         },
       ];
       const action = await loadFixture(cloneEventAction(fixtures, erc721));
-      expect(
-        await action.validateActionSteps({ logs }),
-      ).toBe(true);
+      expect(await action.validateActionSteps({ logs })).toBe(true);
     });
 
-    describe('string event actions', () => {
-      test('cannot parse and validate contains for an emitted string event with an indexed param', async () => {
+    describe("string event actions", () => {
+      test("cannot parse and validate contains for an emitted string event with an indexed param", async () => {
         const action = await loadFixture(
           cloneStringEventAction(
             fixtures,
             indexedStringErc721TransferAction(
               FilterType.CONTAINS,
-              toHex('ello'),
+              toHex("ello"),
               stringEmitterFixtures.address,
               erc721,
             ),
           ),
         );
 
-        await stringEmitterFixtures.emitIndexedString('Hello world');
+        await stringEmitterFixtures.emitIndexedString("Hello world");
         await expect(() => action.validateActionSteps()).rejects.toThrowError(
           /Parameter is not transparently stored onchain/,
         );
       });
-      test('can parse and validate contains for an emitted string event', async () => {
+      test("can parse and validate contains for an emitted string event", async () => {
         const action = await loadFixture(
           cloneStringEventAction(
             fixtures,
             stringErc721TransferAction(
               FilterType.CONTAINS,
-              toHex('ello'),
+              toHex("ello"),
               stringEmitterFixtures.address,
               erc721,
             ),
           ),
         );
-        await stringEmitterFixtures.emitString('Hello world');
+        await stringEmitterFixtures.emitString("Hello world");
         expect(await action.validateActionSteps()).toBe(true);
       });
-      test('can parse and validate regex for an emitted string event', async () => {
+      test("can parse and validate regex for an emitted string event", async () => {
         const action = await loadFixture(
           cloneStringEventAction(
             fixtures,
             stringErc721TransferAction(
               FilterType.REGEX,
-              toHex('[hH]ello'),
+              toHex("[hH]ello"),
               stringEmitterFixtures.address,
               erc721,
             ),
           ),
         );
 
-        await stringEmitterFixtures.emitString('Hello world');
+        await stringEmitterFixtures.emitString("Hello world");
         expect(await action.validateActionSteps()).toBe(true);
       });
     });
   });
 });
 
-describe('EventAction Func Selector', () => {
+describe("EventAction Func Selector", () => {
   beforeEach(async () => {
     erc721 = await loadFixture(fundErc721(defaultOptions));
     erc20 = await loadFixture(fundErc20(defaultOptions));
   });
 
-  test('can be deployed successfully', async () => {
+  test("can be deployed successfully", async () => {
     const action = new EventAction(
       defaultOptions,
       basicErc721MintFuncAction(erc721),
@@ -490,12 +487,12 @@ describe('EventAction Func Selector', () => {
     expect(isAddress(action.assertValidAddress())).toBe(true);
   });
 
-  test('validates function action step with correct hash', async () => {
+  test("validates function action step with correct hash", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
     const recipient = accounts[1].account;
     const { hash } = await erc721.mintRaw(recipient, {
-      value: parseEther('.1'),
+      value: parseEther(".1"),
     });
 
     expect(
@@ -505,7 +502,7 @@ describe('EventAction Func Selector', () => {
     ).toBe(true);
   });
 
-  test('throws an error when hash is missing', async () => {
+  test("throws an error when hash is missing", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
     try {
@@ -513,18 +510,18 @@ describe('EventAction Func Selector', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(Error);
       expect((e as Error).message).toBe(
-        'Hash is required for function validation',
+        "Hash is required for function validation",
       );
     }
   });
 
-  test('validates function step with EQUAL filter', async () => {
+  test("validates function step with EQUAL filter", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
 
     const recipient = accounts[1].account;
     const { hash } = await erc721.mintRaw(recipient, {
-      value: parseEther('.1'),
+      value: parseEther(".1"),
     });
 
     const criteriaMatch = await action.isActionFunctionValid(actionSteps[0], {
@@ -534,18 +531,18 @@ describe('EventAction Func Selector', () => {
     expect(criteriaMatch).toBe(true);
   });
 
-  test('fails validation with incorrect function signature', async () => {
+  test("fails validation with incorrect function signature", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
     const recipient = accounts[1].account;
 
     const invalidStep = {
       ...actionSteps[0],
-      signature: pad(funcSelectors['mint(address to, uint256 amount)'] as Hex), // Intentional mismatch
+      signature: funcSelectors["mint(address to, uint256 amount)"] as Hex, // Intentional mismatch
     };
 
     const { hash } = await erc721.mintRaw(recipient, {
-      value: parseEther('.1'),
+      value: parseEther(".1"),
     });
 
     try {
@@ -558,13 +555,13 @@ describe('EventAction Func Selector', () => {
     }
   });
 
-  test('validates against NOT_EQUAL filter criteria', async () => {
+  test("validates against NOT_EQUAL filter criteria", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const actionSteps = await action.getActionSteps();
     actionSteps[0].actionParameter.filterType = FilterType.NOT_EQUAL;
     const recipient = accounts[2].account;
     const { hash } = await erc721.mintRaw(recipient, {
-      value: parseEther('.1'),
+      value: parseEther(".1"),
     });
 
     expect(
@@ -574,7 +571,7 @@ describe('EventAction Func Selector', () => {
     ).toBe(true);
   });
 
-  test('validates GREATER_THAN criteria for numeric values', async () => {
+  test("validates GREATER_THAN criteria for numeric values", async () => {
     const action = await loadFixture(cloneFunctionAction20(fixtures, erc20));
     const actionSteps = await action.getActionSteps();
 
@@ -582,7 +579,7 @@ describe('EventAction Func Selector', () => {
       filterType: FilterType.GREATER_THAN,
       fieldType: PrimitiveType.UINT,
       fieldIndex: 1,
-      filterData: toHex('1'),
+      filterData: toHex("1"),
     };
 
     const address = accounts[1].account;
@@ -596,14 +593,14 @@ describe('EventAction Func Selector', () => {
     ).toBe(true);
   });
 
-  test('validates LESS_THAN criteria for numeric values', async () => {
+  test("validates LESS_THAN criteria for numeric values", async () => {
     const action = await loadFixture(cloneFunctionAction20(fixtures, erc20));
     const actionSteps = await action.getActionSteps();
     actionSteps[0].actionParameter = {
       filterType: FilterType.LESS_THAN,
       fieldType: PrimitiveType.UINT,
       fieldIndex: 1,
-      filterData: toHex('5'),
+      filterData: toHex("5"),
     };
 
     const address = accounts[1].account;
@@ -617,16 +614,16 @@ describe('EventAction Func Selector', () => {
     ).toBe(true);
   });
 
-  test('validates entire flow of function action', async () => {
+  test("validates entire flow of function action", async () => {
     const action = await loadFixture(cloneFunctionAction(fixtures, erc721));
     const recipient = accounts[1].account;
     const { hash } = await erc721.mintRaw(recipient, {
-      value: parseEther('.1'),
+      value: parseEther(".1"),
     });
 
     expect(
       await action.validateActionSteps({
-        hash ,
+        hash,
       }),
     ).toBe(true);
   });

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -24,6 +24,7 @@ import {
   encodeAbiParameters,
   fromHex,
   isAddressEqual,
+  pad,
   trim,
 } from 'viem';
 import { getLogs } from 'viem/actions';
@@ -615,7 +616,8 @@ export class EventAction extends DeployableTarget<
     params?: ValidateFunctionStepParams & { chainId?: number },
   ) {
     const criteria = actionStep.actionParameter;
-    const signature = trim(actionStep.signature);
+    let signature = actionStep.signature;
+
     if (!params || !params?.hash) {
       // Should we return false in this case?
       throw new Error('Hash is required for function validation');

--- a/packages/signatures/build.js
+++ b/packages/signatures/build.js
@@ -1,6 +1,7 @@
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { parseAbiItem, toEventSelector, toFunctionSelector } from 'viem';
+import { pad } from 'viem';
 import events from './manifests/events.json' with { type: 'json' };
 import functions from './manifests/functions.json' with { type: 'json' };
 
@@ -31,7 +32,7 @@ function generateSelector(type, signature) {
     case 'event':
       return toEventSelector(signature);
     case 'function':
-      return toFunctionSelector(signature);
+      return pad(toFunctionSelector(signature));
     default:
       throw new Error(`Invalid type: ${type}`);
   }


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/rabbitholegg/boost-protocol/blob/main/.github/CONTRIBUTING.md) to this repository.

### Description
action step signatures were changed to bytes32, this change pads the function signature generation at build time

💔 Thank you!
