### PR TITLE
[ADHOC]: update ENS tests to use register function selector

### DIFF
--- a/.changeset/fuzzy-walls-eat.md
+++ b/.changeset/fuzzy-walls-eat.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/signatures": patch
+---
+
+add register function selector to signatures

--- a/examples/ens-register/src/ens-register.test.ts
+++ b/examples/ens-register/src/ens-register.test.ts
@@ -1,4 +1,4 @@
-import { selectors } from '@boostxyz/signatures/events';
+import { selectors } from '@boostxyz/signatures/functions';
 import {
   loadFixture,
   mine,
@@ -21,7 +21,6 @@ import {
   PrimitiveType,
   SignatureType,
 } from '@boostxyz/sdk';
-import { BoostCore } from '@boostxyz/sdk/BoostCore';
 import { StrategyType } from '@boostxyz/sdk/claiming';
 import { accounts } from '@boostxyz/test/accounts';
 import {
@@ -36,7 +35,7 @@ let fixtures: Fixtures;
 let budgets: BudgetFixtures;
 
 // This is the ens register controller contract
-const targetContract = '0xFED6a969AaA60E4961FCD3EBF1A2e8913ac65B72';
+const targetContract: Address = '0xFED6a969AaA60E4961FCD3EBF1A2e8913ac65B72';
 
 // For this test the incentiveData doesn't matter but we'll use a random value to ensure the signing is working as expected
 const incentiveData = pad('0xdef456232173821931823712381232131391321934');
@@ -52,7 +51,7 @@ const CHAIN_URL =
   'https://eth-sepolia.g.alchemy.com/v2/' + process.env.VITE_ALCHEMY_API_KEY;
 const CHAIN_BLOCK = 6717970n; // block before the commit transaction
 const selector = selectors[
-  'NameRegistered(string,bytes32,address,uint256,uint256,uint256)'
+  "register(string name,address owner,uint256 duration,bytes32 secret,address resolver,bytes[] data,bool reverseRecord,uint16 ownerControlledFuses)"
 ] as Hex;
 
 // https://sepolia.etherscan.io/tx/0xe527caab33384a58780aa12218c159c0b1910921aca0bc311a9dd7c39efb3316
@@ -77,29 +76,28 @@ describe(
         jsonRpcUrl: CHAIN_URL,
         blockNumber: CHAIN_BLOCK,
       });
-      fixtures = await loadFixture(deployFixtures(defaultOptions));
+      fixtures = await loadFixture(deployFixtures(defaultOptions, 11155111));
       budgets = await loadFixture(fundBudget(defaultOptions, fixtures));
     });
 
     test('should create a boost for incentivizing ENS registration', async () => {
       const { budget, erc20 } = budgets;
 
-      const { core, bases } = fixtures;
+      const { core } = fixtures;
       const owner = defaultOptions.account.address;
       // This is a workaround to this known issue: https://github.com/NomicFoundation/hardhat/issues/5511
       await mine();
 
-      // Step defining the action for Transfer event
+      // Step defining the action
       const eventActionStep: ActionStep = {
         chainid: sepolia.id,
-        signature: selector, // NameRegistered(string,bytes32,address,uint256,uint256,uint256)
-        signatureType: SignatureType.EVENT, // We're working with an event
+        signature: selector, // register function selector
+        signatureType: SignatureType.FUNC, // We're working with a function
         targetContract: targetContract, // Address of the targetContract
-        // We want to target the Minter property on the Purchase event
         actionParameter: {
           filterType: FilterType.EQUAL, // Filter to check for equality
           fieldType: PrimitiveType.ADDRESS, // The field we're filtering is an address
-          fieldIndex: 2, // The topic for the parameter we're filtering
+          fieldIndex: 1, // The owner function parameter
           filterData: boostImpostor, // Filtering based on minters address
         },
       };
@@ -108,18 +106,16 @@ describe(
       const eventActionPayload = {
         actionClaimant: {
           chainid: sepolia.id,
-          signatureType: SignatureType.EVENT,
-          signature: selector, // NameRegistered(string,bytes32,address,uint256,uint256,uint256)
-          fieldIndex: 0, // Targeting the 'from' address
-          targetContract: boostImpostor, // The ERC20 contract we're monitoring
+          signatureType: SignatureType.FUNC,
+          signature: selector, // register function selector
+          fieldIndex: 1, // Targeting the 'from' address
+          targetContract: targetContract, // The ERC20 contract we're monitoring
         },
         actionSteps: [eventActionStep],
       };
       // Initialize EventAction with the custom payload
-      const eventAction = new bases.EventAction(
-        defaultOptions,
-        eventActionPayload,
-      );
+      const eventAction = core.EventAction(eventActionPayload);
+
       // Create the boost using the custom EventAction
       await core.createBoost({
         protocolFee: 250n,
@@ -127,16 +123,13 @@ describe(
         maxParticipants: 100n,
         budget: budget,
         action: eventAction,
-        validator: new bases.SignerValidator(defaultOptions, {
+        validator: core.SignerValidator({
           signers: [owner, trustedSigner.account],
           validatorCaller: fixtures.core.assertValidAddress(), // only core should be calling into the validate otherwise it's possible to burn signatures
         }),
-        allowList: new bases.SimpleDenyList(defaultOptions, {
-          owner: owner,
-          denied: [],
-        }),
+        allowList: core.OpenAllowList(),
         incentives: [
-          new bases.ERC20Incentive(defaultOptions, {
+          core.ERC20Incentive({
             asset: erc20.assertValidAddress(),
             reward: parseEther('1'),
             limit: 100n,
@@ -174,16 +167,16 @@ describe(
         params: ['0x3c'], // increase time by 60 seconds
       });
 
-      const registerReceipt = await walletClient.sendTransaction({
+      const hash = await walletClient.sendTransaction({
         data: inputData,
         account: boostImpostor,
         to: targetContract,
         value: parseEther('0.408279452054767655'),
       });
       // Make sure that the transaction was sent as expected and validates the action
-      expect(registerReceipt).toBeDefined();
+      expect(hash).toBeDefined();
 
-      const validation = await action.validateActionSteps();
+      const validation = await action.validateActionSteps({ hash });
       expect(validation).toBe(true);
       // Generate the signature using the trusted signer
       const claimDataPayload = await boost.validator.encodeClaimData({
@@ -196,7 +189,7 @@ describe(
       });
 
       // Claim the incentive for the imposter
-      await fixtures.core.claimIncentiveFor(
+      await core.claimIncentiveFor(
         boost.id,
         0n,
         referrer,

--- a/examples/ens-register/vitest.config.ts
+++ b/examples/ens-register/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   define: {
-    __DEFAULT_CHAIN_ID__: 31337,
+    __DEFAULT_CHAIN_ID__: 11155111,
   },
   test: {
     fileParallelism: false,

--- a/packages/signatures/manifests/functions.json
+++ b/packages/signatures/manifests/functions.json
@@ -2,6 +2,7 @@
   "// Begin common builtin function signatures",
   "mint(address to, uint256 amount)",
   "mintPayable(address to, uint256 amount)",
+  "register(string name,address owner,uint256 duration,bytes32 secret,address resolver,bytes[] data,bool reverseRecord,uint16 ownerControlledFuses)",
   "// Test function signatures",
   "mint(address)"
 ]

--- a/test/src/viem.ts
+++ b/test/src/viem.ts
@@ -8,7 +8,7 @@ import {
   zeroHash,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { base, hardhat } from 'viem/chains';
+import { base, hardhat, sepolia } from 'viem/chains';
 import { accounts } from './accounts';
 
 const { account, key } = accounts.at(0) || {
@@ -35,7 +35,7 @@ export type TestClient = ReturnType<typeof makeTestClient>;
 export function setupConfig(walletClient = makeTestClient()) {
   return createConfig({
     ssr: true,
-    chains: [hardhat, base],
+    chains: [hardhat, base, sepolia],
     client: () => walletClient,
   });
 }


### PR DESCRIPTION
### Description
- changes ENS test to use register function selector instead of using the `NameRegistered` event. The event used a bytes32 value for the address, and bytes comparison is not allowed on indexed event args.
- updates test to work in new examples directory.
- adds register function selector to signatures package
- adds sepolia to wagmi config in `/test/src/viem.ts`
