### PR TITLE
[ADHOC] Fix uint equals comparison

### DIFF
--- a/.changeset/spotty-rings-drop.md
+++ b/.changeset/spotty-rings-drop.md
@@ -1,0 +1,5 @@
+---
+"@boostxyz/sdk": patch
+---
+
+fixes field validation for uint

--- a/packages/sdk/src/Actions/EventAction.ts
+++ b/packages/sdk/src/Actions/EventAction.ts
@@ -680,6 +680,8 @@ export class EventAction extends DeployableTarget<
       case FilterType.EQUAL:
         if (criteria.fieldType === PrimitiveType.ADDRESS) {
           return isAddressEqual(criteria.filterData, fieldValue as Address);
+        } else if (criteria.fieldType === PrimitiveType.UINT) {
+          return BigInt(fieldValue) === BigInt(criteria.filterData);
         }
         return fieldValue === criteria.filterData;
 


### PR DESCRIPTION
### Description
Currently, the hex value gets compared to a number/bigint. This always returns a false case, so casting both fields into a bigint will compare the actual intended values

fix #151 