### PR TITLE
[BOOST-4790] fix UINT field comparisons

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -199,7 +199,8 @@
     "typedoc": "npx typedoc --tsconfig ./tsconfig.build.json --sort required-first --sort visibility --sort kind"
   },
   "dependencies": {
-    "@boostxyz/signatures": "workspace:*"
+    "@boostxyz/signatures": "workspace:*",
+    "ts-pattern": "5.4.0"
   },
   "optionalDependencies": {
     "@boostxyz/evm": "workspace:*",

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "composite": true
   },
-  "exclude": ["dist", "build", "node_modules"],
+  "exclude": ["build", "node_modules"],
   "references": [
     {
       "path": "../evm"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 2.1.1(vitest@2.1.1(@types/node@20.16.10)(terser@5.31.1))
       '@wagmi/core':
         specifier: 2.13.8
-        version: 2.13.8(@tanstack/query-core@5.32.0)(@types/react@18.3.0)(immer@10.0.2)(react@18.3.0)(typescript@5.6.2)(viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8))
+        version: 2.13.8(@tanstack/query-core@5.32.0)(@types/react@18.3.0)(immer@10.0.2)(react@18.3.0)(typescript@5.6.2)(viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8))
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -82,7 +82,7 @@ importers:
         version: 5.6.2
       viem:
         specifier: 2.21.16
-        version: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+        version: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
       vite:
         specifier: ^5.4.8
         version: 5.4.8(@types/node@20.16.10)(terser@5.31.1)
@@ -151,7 +151,7 @@ importers:
     dependencies:
       '@wagmi/core':
         specifier: 2.13.8
-        version: 2.13.8(@tanstack/query-core@5.32.0)(@types/react@18.3.0)(immer@10.0.2)(react@18.3.0)(typescript@5.6.2)(viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8))
+        version: 2.13.8(@tanstack/query-core@5.32.0)(@types/react@18.3.0)(immer@10.0.2)(react@18.3.0)(typescript@5.6.2)(viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8))
     devDependencies:
       '@nomicfoundation/hardhat-foundry':
         specifier: ^1.1.2
@@ -188,7 +188,7 @@ importers:
         version: 5.6.2
       viem:
         specifier: 2.21.16
-        version: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+        version: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
 
   packages/sdk:
     dependencies:
@@ -198,6 +198,9 @@ importers:
       abitype:
         specifier: '1'
         version: 1.0.6(typescript@5.6.2)(zod@3.23.8)
+      ts-pattern:
+        specifier: 5.4.0
+        version: 5.4.0
       viem:
         specifier: 2.x
         version: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
@@ -3939,6 +3942,9 @@ packages:
       '@swc/wasm':
         optional: true
 
+  ts-pattern@5.4.0:
+    resolution: {integrity: sha512-hgfOMfjlrARCnYtGD/xEAkFHDXuSyuqjzFSltyQCbN689uNvoQL20TVN2XFcLMjfNuwSsQGU+xtH6MrjIwhwUg==}
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -5316,7 +5322,7 @@ snapshots:
       '@nomicfoundation/hardhat-viem': 2.0.4(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))(typescript@5.6.2))(typescript@5.6.2)(viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8))(zod@3.23.8)
       '@nomicfoundation/ignition-core': 0.15.6(bufferutil@4.0.8)
       hardhat: 2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))(typescript@5.6.2)
-      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
 
   '@nomicfoundation/hardhat-ignition-viem@0.15.6(@nomicfoundation/hardhat-ignition@0.15.6(@nomicfoundation/hardhat-verify@2.0.6(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)))(bufferutil@4.0.8)(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)))(@nomicfoundation/hardhat-viem@2.0.5(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2))(typescript@5.6.2)(viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8))(zod@3.23.8))(@nomicfoundation/ignition-core@0.15.6(bufferutil@4.0.8))(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2))(viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8))':
     dependencies:
@@ -5324,7 +5330,7 @@ snapshots:
       '@nomicfoundation/hardhat-viem': 2.0.5(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2))(typescript@5.6.2)(viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8))(zod@3.23.8)
       '@nomicfoundation/ignition-core': 0.15.6(bufferutil@4.0.8)
       hardhat: 2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)
-      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
 
   '@nomicfoundation/hardhat-ignition@0.15.6(@nomicfoundation/hardhat-verify@2.0.6(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))(typescript@5.6.2)))(bufferutil@4.0.8)(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))(typescript@5.6.2))':
     dependencies:
@@ -5385,7 +5391,7 @@ snapshots:
       solidity-coverage: 0.8.12(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2))
       ts-node: 10.9.2(@types/node@22.7.4)(typescript@5.6.2)
       typescript: 5.6.2
-      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
 
   '@nomicfoundation/hardhat-toolbox-viem@3.0.0(vfcvgejr3sobymxrk23mkjyifm)':
     dependencies:
@@ -5404,7 +5410,7 @@ snapshots:
       solidity-coverage: 0.8.12(hardhat@2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))(typescript@5.6.2))
       ts-node: 10.9.2(@types/node@20.16.10)(typescript@5.6.2)
       typescript: 5.6.2
-      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
 
   '@nomicfoundation/hardhat-toolbox@5.0.0(g6f2536seyf22b2cklftu3x2ae)':
     dependencies:
@@ -5463,7 +5469,7 @@ snapshots:
       hardhat: 2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))(typescript@5.6.2)
       lodash.memoize: 4.1.2
       typescript: 5.6.2
-      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
     transitivePeerDependencies:
       - zod
 
@@ -5473,7 +5479,7 @@ snapshots:
       hardhat: 2.22.12(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)
       lodash.memoize: 4.1.2
       typescript: 5.6.2
-      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
     transitivePeerDependencies:
       - zod
 
@@ -5962,7 +5968,7 @@ snapshots:
       picocolors: 1.1.0
       picomatch: 3.0.1
       prettier: 3.3.3
-      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
       zod: 3.23.8
     optionalDependencies:
       typescript: 5.6.2
@@ -5975,6 +5981,20 @@ snapshots:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.6.2)
       viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@6.0.4)(zod@3.23.8)
+      zustand: 4.4.1(@types/react@18.3.0)(immer@10.0.2)(react@18.3.0)
+    optionalDependencies:
+      '@tanstack/query-core': 5.32.0
+      typescript: 5.6.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+
+  '@wagmi/core@2.13.8(@tanstack/query-core@5.32.0)(@types/react@18.3.0)(immer@10.0.2)(react@18.3.0)(typescript@5.6.2)(viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.6.2)
+      viem: 2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8)
       zustand: 4.4.1(@types/react@18.3.0)(immer@10.0.2)(react@18.3.0)
     optionalDependencies:
       '@tanstack/query-core': 5.32.0
@@ -6837,7 +6857,7 @@ snapshots:
       '@types/node': 18.15.13
       aes-js: 4.0.0-beta.5
       tslib: 2.4.0
-      ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 8.17.1(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7495,6 +7515,10 @@ snapshots:
   isows@1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)):
     dependencies:
       ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+
+  isows@1.0.4(ws@8.17.1(bufferutil@4.0.8)):
+    dependencies:
+      ws: 8.17.1(bufferutil@4.0.8)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -8728,6 +8752,8 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-pattern@5.4.0: {}
+
   tslib@1.14.1: {}
 
   tslib@2.4.0: {}
@@ -8904,6 +8930,24 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.21.16(bufferutil@4.0.8)(typescript@5.6.2)(zod@3.23.8):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.4.0
+      '@noble/hashes': 1.4.0
+      '@scure/bip32': 1.4.0
+      '@scure/bip39': 1.4.0
+      abitype: 1.0.5(typescript@5.6.2)(zod@3.23.8)
+      isows: 1.0.4(ws@8.17.1(bufferutil@4.0.8))
+      webauthn-p256: 0.0.5
+      ws: 8.17.1(bufferutil@4.0.8)
+    optionalDependencies:
+      typescript: 5.6.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-node@2.1.1(@types/node@20.16.10)(terser@5.31.1):
     dependencies:
       cac: 6.7.14
@@ -9039,6 +9083,10 @@ snapshots:
       bufferutil: 4.0.8
 
   ws@7.5.10(bufferutil@4.0.8):
+    optionalDependencies:
+      bufferutil: 4.0.8
+
+  ws@8.17.1(bufferutil@4.0.8):
     optionalDependencies:
       bufferutil: 4.0.8
 


### PR DESCRIPTION
The refactor to utilize decoded args broke uint equality comparisons and
this fixes it. I've also taken this opportunity to add unit tests to
catch regressions for these comparisons in CI and during other work,
since writing e2e cases is much more arduous and that focus prevented us
from covering against potential regressions here.

resolves #151 
