### PR TITLE
[ADHOC] chore: simplify hardhat config

### DIFF
--- a/packages/sdk/hardhat.config.cjs
+++ b/packages/sdk/hardhat.config.cjs
@@ -1,20 +1,5 @@
 require('dotenv').config();
 
 module.exports = {
-  networks: {
-    ...(process.env.VITE_ALCHEMY_API_KEY
-      ? {
-          hardhat: {
-            // We might not need the mine() function if we use this code https://github.com/NomicFoundation/hardhat/pull/5394/files
-            chainId: 8453, // Base chain ID
-            //hardfork: 'cancun',
-            forking: {
-              url:
-                'https://base-mainnet.g.alchemy.com/v2/' +
-                process.env.VITE_ALCHEMY_API_KEY,
-            },
-          },
-        }
-      : {}),
-  },
+  networks: {},
 };


### PR DESCRIPTION
### Description
If there is a valid `VITE_ALCHEMY_API_KEY`, then `pnpm test` may not run
![CleanShot 2024-10-03 at 17 18 39@2x](https://github.com/user-attachments/assets/430ff75a-6beb-45df-8534-28f1fe98bc25)

Now that the examples exist outside of the sdk package, we can simplify the hardhat config